### PR TITLE
fix: add .NET and Python SDK setup to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -117,6 +122,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

- Add `actions/setup-dotnet@v4` with .NET 8.0.x SDK to the `build` job
- Add `actions/setup-dotnet@v4` with .NET 8.0.x SDK to the `release` job  
- Add `actions/setup-python@v5` to the `release` job (needed for husky pre-push hook)

This fixes the release job failure caused by the husky pre-push hook running `pnpm typecheck` without the required language SDKs installed. GitHub's `ubuntu-latest` now ships with .NET 10 preview by default, but our C# fixtures target .NET 8.

## Test plan

- [ ] CI build job passes (typecheck includes C# fixtures)
- [ ] After merge, release job successfully pushes tags

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)