### PR TITLE
fix(doctor): use workflow install-local for version update fix

### DIFF
--- a/.changeset/doctor-fix-workflow.md
+++ b/.changeset/doctor-fix-workflow.md
@@ -1,0 +1,10 @@
+---
+"@pietgk/devac-cli": patch
+---
+
+Fix doctor --fix to use workflow install-local command
+
+- Changed version-check.ts to delegate fix commands to `devac workflow install-local`
+- Updated formatters.ts to always show error details when fixes fail (not just with --verbose)
+
+This eliminates duplicate CLI linking logic and provides better error visibility.

--- a/packages/devac-cli/src/commands/doctor/checks/version-check.ts
+++ b/packages/devac-cli/src/commands/doctor/checks/version-check.ts
@@ -102,16 +102,12 @@ const versionCheck: HealthCheck = {
         let fixable = true;
 
         if (context.isDevacWorkspace && context.workspaceRoot) {
-          // All 3 CLIs from current workspace
-          fixCommand =
-            "git pull && pnpm install && pnpm build && " +
-            "(cd packages/devac-cli && pnpm link --global) && " +
-            "(cd packages/devac-mcp && pnpm link --global) && " +
-            "(cd packages/devac-worktree && pnpm link --global)";
+          // Inside devac workspace - delegate to workflow command
+          fixCommand = "git pull && pnpm install && devac workflow install-local";
         } else if (context.installMethod === "pnpm-link" && context.linkedWorkspaceRoot) {
-          // All 3 CLIs from linked source
+          // pnpm-linked from another directory - use --path option
           const root = context.linkedWorkspaceRoot;
-          fixCommand = `(cd ${root} && git pull && pnpm install && pnpm build && (cd packages/devac-cli && pnpm link --global) && (cd packages/devac-mcp && pnpm link --global) && (cd packages/devac-worktree && pnpm link --global))`;
+          fixCommand = `(cd ${root} && git pull && pnpm install) && devac workflow install-local --path ${root}`;
         } else if (context.installMethod === "pnpm-link") {
           // pnpm-linked but couldn't find source - user needs to update manually
           fixCommand =

--- a/packages/devac-cli/src/commands/doctor/formatters.ts
+++ b/packages/devac-cli/src/commands/doctor/formatters.ts
@@ -102,7 +102,7 @@ export function formatDoctorOutput(result: DoctorResult, options: DoctorOptions)
     for (const fix of result.fixesApplied) {
       const icon = fix.success ? STATUS_ICONS.pass : STATUS_ICONS.fail;
       lines.push(`  ${icon} ${fix.message}`);
-      if (fix.error && options.verbose) {
+      if (!fix.success && fix.error) {
         lines.push(`    Error: ${fix.error}`);
       }
     }


### PR DESCRIPTION
## Summary

- Changed `devac doctor --fix` to delegate version update fixes to `devac workflow install-local` instead of duplicating shell commands
- Updated error display to always show fix errors (not just with `--verbose` flag)

## Changes

**@pietgk/devac-cli**

- `version-check.ts`: Replaced hardcoded pnpm link commands with `devac workflow install-local`
  - Inside workspace: `git pull && pnpm install && devac workflow install-local`
  - Outside workspace (linked): Uses `--path` option to target workspace
- `formatters.ts`: Changed error display from `options.verbose` to `!fix.success` condition

## Benefits

- **DRY**: Single source of truth for CLI installation logic
- **Better UX**: Errors are always visible when fixes fail
- **Consistency**: Same behavior between manual and auto-fix paths

## Test Plan

- [x] TypeScript type checking passes
- [x] All 309 tests pass
- [x] Compiled code verified

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)