### PR TITLE
feat(cli): add devac sync command for streamlined analyze + register workflow

### DIFF
--- a/.changeset/add-sync-command.md
+++ b/.changeset/add-sync-command.md
@@ -1,0 +1,11 @@
+---
+"@pietgk/devac-cli": minor
+---
+
+Add `devac sync` command to streamline analyze + register workflow
+
+- New `devac sync` command combines package analysis and hub registration
+- Supports `--analyze-only`, `--register-only`, `--force`, and `--dry-run` flags
+- Uses `--if-changed` optimization by default for faster incremental syncs
+- **Breaking**: `devac hub register` no longer auto-analyzes packages (use `devac sync` instead)
+- Status command now recommends `devac sync` in "Next Steps"

--- a/packages/devac-cli/__tests__/sync.test.ts
+++ b/packages/devac-cli/__tests__/sync.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Sync Command Tests
+ *
+ * Tests for the `devac sync` command which combines analyze + register.
+ */
+
+import * as fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { hubInit } from "../src/commands/hub-init.js";
+import { syncCommand } from "../src/commands/sync.js";
+
+describe("sync command", () => {
+  let tempDir: string;
+  let workspaceDir: string;
+  let hubDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), "devac-sync-test-"));
+    workspaceDir = path.join(tempDir, "workspace");
+    hubDir = path.join(workspaceDir, ".devac");
+
+    await fs.mkdir(workspaceDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper to create a mock repo with optional seed data
+   */
+  async function createMockRepo(
+    repoPath: string,
+    options: {
+      name?: string;
+      hasSeeds?: boolean;
+      gitRemote?: string;
+    } = {}
+  ): Promise<void> {
+    const { name = "test-pkg", hasSeeds = false, gitRemote } = options;
+
+    await fs.mkdir(repoPath, { recursive: true });
+
+    // Create git directory
+    await fs.mkdir(path.join(repoPath, ".git"), { recursive: true });
+    await fs.writeFile(path.join(repoPath, ".git", "HEAD"), "ref: refs/heads/main\n");
+    if (gitRemote) {
+      await fs.writeFile(
+        path.join(repoPath, ".git", "config"),
+        `[remote "origin"]\n  url = ${gitRemote}\n`
+      );
+    }
+
+    // Create package.json
+    await fs.writeFile(
+      path.join(repoPath, "package.json"),
+      JSON.stringify({ name, version: "1.0.0" })
+    );
+
+    // Create a source file for analysis
+    await fs.mkdir(path.join(repoPath, "src"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoPath, "src", "index.ts"),
+      'export function hello() { return "world"; }\n'
+    );
+
+    // Optionally create seeds
+    if (hasSeeds) {
+      const seedPath = path.join(repoPath, ".devac", "seed", "base");
+      await fs.mkdir(seedPath, { recursive: true });
+
+      await fs.writeFile(
+        path.join(seedPath, "stats.json"),
+        JSON.stringify({ nodeCount: 10, edgeCount: 5, refCount: 2, fileCount: 3 })
+      );
+
+      await fs.writeFile(path.join(seedPath, "nodes.parquet"), "mock");
+      await fs.writeFile(path.join(seedPath, "edges.parquet"), "mock");
+      await fs.writeFile(path.join(seedPath, "external_refs.parquet"), "mock");
+
+      await fs.writeFile(
+        path.join(repoPath, ".devac", "seed", "meta.json"),
+        JSON.stringify({ schemaVersion: "2.1" })
+      );
+    }
+  }
+
+  it("fails if not in a workspace", async () => {
+    const result = await syncCommand({
+      path: path.join(tempDir, "not-a-workspace"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Not in a workspace");
+  });
+
+  it("fails if hub is not initialized", async () => {
+    // Create a repo to make it a valid workspace
+    await createMockRepo(path.join(workspaceDir, "repo1"), {
+      gitRemote: "git@github.com:test/repo1.git",
+      hasSeeds: true,
+    });
+
+    const result = await syncCommand({
+      path: workspaceDir,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Hub not initialized");
+  });
+
+  it("dry run reports what would be done", async () => {
+    // Create workspace with hub
+    await createMockRepo(path.join(workspaceDir, "repo1"), {
+      gitRemote: "git@github.com:test/repo1.git",
+      hasSeeds: false, // Needs analysis
+    });
+    await hubInit({ hubDir });
+
+    const progress: string[] = [];
+    const result = await syncCommand({
+      path: workspaceDir,
+      dryRun: true,
+      onProgress: (msg) => progress.push(msg),
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.packagesAnalyzed).toBe(0);
+    expect(result.reposRegistered).toBe(0);
+    expect(result.message).toContain("Dry run");
+    expect(progress.some((p) => p.includes("Dry run"))).toBe(true);
+  });
+
+  it("analyze-only skips registration", async () => {
+    // Create workspace with already analyzed repo
+    await createMockRepo(path.join(workspaceDir, "repo1"), {
+      gitRemote: "git@github.com:test/repo1.git",
+      hasSeeds: true,
+    });
+    await hubInit({ hubDir });
+
+    const result = await syncCommand({
+      path: workspaceDir,
+      analyze: true,
+      register: false, // Skip registration
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.reposRegistered).toBe(0);
+  });
+
+  it("register-only skips analysis", async () => {
+    // Create workspace with already analyzed repo
+    await createMockRepo(path.join(workspaceDir, "repo1"), {
+      gitRemote: "git@github.com:test/repo1.git",
+      hasSeeds: true,
+    });
+    await hubInit({ hubDir });
+
+    const result = await syncCommand({
+      path: workspaceDir,
+      analyze: false, // Skip analysis
+      register: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.packagesAnalyzed).toBe(0);
+    expect(result.reposRegistered).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns success with nothing to do when workspace is up-to-date", async () => {
+    // Create workspace with already analyzed and registered repo
+    await createMockRepo(path.join(workspaceDir, "repo1"), {
+      gitRemote: "git@github.com:test/repo1.git",
+      hasSeeds: true,
+    });
+    await hubInit({ hubDir });
+
+    // First sync to register
+    await syncCommand({
+      path: workspaceDir,
+      analyze: false, // Skip analysis since we have mock seeds
+      register: true,
+    });
+
+    // Second sync should have nothing to do (except re-register)
+    const result = await syncCommand({
+      path: workspaceDir,
+      analyze: false, // Skip analysis
+      register: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/devac-cli/src/commands/hub-init.ts
+++ b/packages/devac-cli/src/commands/hub-init.ts
@@ -176,10 +176,8 @@ export function registerHubCommand(program: Command): void {
   // hub register
   hub
     .command("register [path]")
-    .description("Register a repository with the hub (analyzes packages without seeds by default)")
+    .description("Register a repository with the hub (use 'devac sync' to analyze + register)")
     .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
-    .option("--analyze", "Analyze packages without base seeds before registering (default: true)")
-    .option("--no-analyze", "Only register, skip analysis")
     .option("--all", "Register all repositories in workspace")
     .action(async (repoPath, options) => {
       try {
@@ -188,7 +186,6 @@ export function registerHubCommand(program: Command): void {
         const result = await hubRegister({
           hubDir,
           repoPath: resolvedPath,
-          analyze: options.analyze,
           all: options.all,
           onProgress: (msg) => console.log(msg),
         });

--- a/packages/devac-cli/src/commands/index.ts
+++ b/packages/devac-cli/src/commands/index.ts
@@ -42,6 +42,9 @@ export { registerWorkflowCommand } from "./workflow/index.js";
 // Doctor command (system health checks)
 export { registerDoctorCommand } from "./doctor.js";
 
+// Sync command (analyze + register workflow)
+export { registerSyncCommand } from "./sync.js";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Command function exports (for programmatic use)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -284,3 +287,7 @@ export type {
 // Doctor command (system health checks)
 export { doctorCommand } from "./doctor.js";
 export type { DoctorOptions, DoctorResult } from "./doctor.js";
+
+// Sync command (analyze + register workflow)
+export { syncCommand } from "./sync.js";
+export type { SyncOptions, SyncResult } from "./sync.js";

--- a/packages/devac-cli/src/commands/status.ts
+++ b/packages/devac-cli/src/commands/status.ts
@@ -836,9 +836,7 @@ export async function statusCommand(options: StatusOptions): Promise<StatusResul
     // Determine next steps based on current state
     // Check for packages needing analysis first
     if (result.seeds && result.seeds.summary.packagesNeedAnalysis > 0) {
-      result.next.push(
-        `Analyze ${result.seeds.summary.packagesNeedAnalysis} package(s): devac hub register --all`
-      );
+      result.next.push("Sync workspace: devac sync");
     }
     // Check for CI failures (highest priority workflow issue)
     if (result.workflow?.available && result.workflow.summary.failing > 0) {
@@ -860,7 +858,7 @@ export async function statusCommand(options: StatusOptions): Promise<StatusResul
     } else if (result.diagnostics.warnings > 0) {
       result.next.push(`Address ${result.diagnostics.warnings} warnings`);
     } else if (!result.health.hubConnected) {
-      result.next.push("Initialize hub: devac hub init");
+      result.next.push("Initialize hub: devac hub init, then devac sync");
     } else if (!result.health.watchActive) {
       result.next.push("Start watch: devac workspace watch");
     } else if (result.next.length === 0) {

--- a/packages/devac-cli/src/commands/sync.ts
+++ b/packages/devac-cli/src/commands/sync.ts
@@ -1,0 +1,283 @@
+/**
+ * Sync Command Implementation
+ *
+ * Primary workflow for ensuring workspace seeds are analyzed and repos are registered.
+ * Combines analyze + register in a single command with optimization by default.
+ */
+
+import * as path from "node:path";
+import {
+  type WorkspaceStatus,
+  createHubClient,
+  findWorkspaceDir,
+  getWorkspaceStatus,
+} from "@pietgk/devac-core";
+import type { Command } from "commander";
+import { analyzeCommand } from "./analyze.js";
+
+/**
+ * Sync command options
+ */
+export interface SyncOptions {
+  /** Path to workspace or repository */
+  path: string;
+  /** Analyze packages needing analysis (default: true) */
+  analyze?: boolean;
+  /** Register repositories with hub (default: true) */
+  register?: boolean;
+  /** Force full reanalysis even if no changes detected (default: false) */
+  force?: boolean;
+  /** Show what would be done without making changes (default: false) */
+  dryRun?: boolean;
+  /** Callback for progress updates */
+  onProgress?: (message: string) => void;
+}
+
+/**
+ * Sync command result
+ */
+export interface SyncResult {
+  /** Whether the command succeeded */
+  success: boolean;
+  /** Number of packages that were analyzed */
+  packagesAnalyzed: number;
+  /** Number of packages skipped (already up-to-date) */
+  packagesSkipped: number;
+  /** Number of repositories registered */
+  reposRegistered: number;
+  /** List of errors encountered */
+  errors: string[];
+  /** User-facing message */
+  message: string;
+}
+
+/**
+ * Sync workspace - analyze packages and register repos with hub
+ */
+export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
+  const {
+    path: inputPath,
+    analyze = true,
+    register = true,
+    force = false,
+    dryRun = false,
+    onProgress,
+  } = options;
+
+  const errors: string[] = [];
+  let packagesAnalyzed = 0;
+  let packagesSkipped = 0;
+  let reposRegistered = 0;
+
+  // Step 1: Find workspace
+  const workspaceDir = await findWorkspaceDir(inputPath);
+  if (!workspaceDir) {
+    return {
+      success: false,
+      packagesAnalyzed: 0,
+      packagesSkipped: 0,
+      reposRegistered: 0,
+      errors: [`Not in a workspace: ${inputPath}`],
+      message: "Not in a workspace. Run from a workspace directory.",
+    };
+  }
+
+  // Step 2: Check hub is initialized
+  const hubDir = path.join(workspaceDir, ".devac");
+  const client = createHubClient({ hubDir });
+
+  try {
+    // This will throw if hub is not initialized
+    await client.getStatus();
+  } catch {
+    return {
+      success: false,
+      packagesAnalyzed: 0,
+      packagesSkipped: 0,
+      reposRegistered: 0,
+      errors: ["Hub not initialized"],
+      message: "Hub not initialized. Run 'devac hub init' first.",
+    };
+  }
+
+  // Step 3: Get workspace status
+  let status: WorkspaceStatus;
+  try {
+    status = await getWorkspaceStatus({ path: workspaceDir });
+  } catch (error) {
+    return {
+      success: false,
+      packagesAnalyzed: 0,
+      packagesSkipped: 0,
+      reposRegistered: 0,
+      errors: [error instanceof Error ? error.message : String(error)],
+      message: "Failed to get workspace status",
+    };
+  }
+
+  // Step 4: Dry run - report what would be done
+  if (dryRun) {
+    const packagesNeedingAnalysis = status.summary.packagesNeedAnalysis;
+    const reposNeedingRegistration = status.repos.filter(
+      (r) => r.hubStatus !== "registered"
+    ).length;
+
+    onProgress?.("Dry run - would perform the following:");
+    if (analyze && packagesNeedingAnalysis > 0) {
+      onProgress?.(`  - Analyze ${packagesNeedingAnalysis} package(s)`);
+    }
+    if (register && reposNeedingRegistration > 0) {
+      onProgress?.(`  - Register ${reposNeedingRegistration} repository(ies)`);
+    }
+    if (packagesNeedingAnalysis === 0 && reposNeedingRegistration === 0) {
+      onProgress?.("  - Nothing to do, workspace is up-to-date");
+    }
+
+    return {
+      success: true,
+      packagesAnalyzed: 0,
+      packagesSkipped: 0,
+      reposRegistered: 0,
+      errors: [],
+      message: `Dry run: would analyze ${packagesNeedingAnalysis} package(s), register ${reposNeedingRegistration} repo(s)`,
+    };
+  }
+
+  // Step 5: Analyze packages if enabled
+  if (analyze) {
+    for (const repo of status.repos) {
+      if (!repo.seedStatus) continue;
+
+      // Find packages needing analysis
+      const packagesNeedingWork = repo.seedStatus.packages.filter((pkg) => !pkg.hasBase);
+
+      if (packagesNeedingWork.length === 0 && !force) {
+        continue;
+      }
+
+      // Analyze each package
+      const packagesToAnalyze = force ? repo.seedStatus.packages : packagesNeedingWork;
+
+      for (const pkg of packagesToAnalyze) {
+        onProgress?.(`Analyzing ${pkg.packageName}...`);
+
+        try {
+          const result = await analyzeCommand({
+            packagePath: pkg.packagePath,
+            repoName: repo.name,
+            branch: "base",
+            ifChanged: !force,
+            force: force,
+          });
+
+          if (result.success) {
+            if (result.skipped) {
+              packagesSkipped++;
+              onProgress?.(`  ⊘ ${pkg.packageName}: skipped (no changes)`);
+            } else {
+              packagesAnalyzed++;
+              onProgress?.(
+                `  ✓ ${pkg.packageName}: ${result.nodesCreated} nodes, ${result.edgesCreated} edges`
+              );
+            }
+          } else {
+            errors.push(`${pkg.packageName}: ${result.error || "Analysis failed"}`);
+            onProgress?.(`  ✗ ${pkg.packageName}: ${result.error || "Analysis failed"}`);
+          }
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          errors.push(`${pkg.packageName}: ${errorMsg}`);
+          onProgress?.(`  ✗ ${pkg.packageName}: ${errorMsg}`);
+        }
+      }
+    }
+  }
+
+  // Step 6: Register repos if enabled
+  if (register) {
+    for (const repo of status.repos) {
+      // Skip if already registered and we didn't analyze anything new
+      if (repo.hubStatus === "registered" && packagesAnalyzed === 0 && !force) {
+        continue;
+      }
+
+      onProgress?.(`Registering ${repo.name}...`);
+
+      try {
+        const result = await client.registerRepo(repo.path);
+        reposRegistered++;
+        onProgress?.(
+          `  ✓ ${result.repoId}: ${result.packages} package(s), ${result.crossRepoEdges} cross-repo edges`
+        );
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        errors.push(`${repo.name}: ${errorMsg}`);
+        onProgress?.(`  ✗ ${repo.name}: ${errorMsg}`);
+      }
+    }
+  }
+
+  // Build summary message
+  const parts: string[] = [];
+  if (packagesAnalyzed > 0) {
+    parts.push(`${packagesAnalyzed} package(s) analyzed`);
+  }
+  if (packagesSkipped > 0) {
+    parts.push(`${packagesSkipped} skipped`);
+  }
+  if (reposRegistered > 0) {
+    parts.push(`${reposRegistered} repo(s) registered`);
+  }
+  if (errors.length > 0) {
+    parts.push(`${errors.length} error(s)`);
+  }
+
+  const message =
+    parts.length > 0 ? `Sync complete: ${parts.join(", ")}` : "Sync complete: nothing to do";
+
+  return {
+    success: errors.length === 0,
+    packagesAnalyzed,
+    packagesSkipped,
+    reposRegistered,
+    errors,
+    message,
+  };
+}
+
+/**
+ * Register the sync command with the CLI
+ */
+export function registerSyncCommand(program: Command): void {
+  program
+    .command("sync")
+    .description("Analyze packages and register repos with hub")
+    .option("-p, --path <path>", "Workspace path", process.cwd())
+    .option("--analyze-only", "Only analyze, don't register")
+    .option("--register-only", "Only register, don't analyze")
+    .option("--force", "Force full reanalysis (ignore --if-changed optimization)")
+    .option("--dry-run", "Show what would be done without making changes")
+    .action(async (opts) => {
+      const result = await syncCommand({
+        path: opts.path,
+        analyze: !opts.registerOnly,
+        register: !opts.analyzeOnly,
+        force: opts.force ?? false,
+        dryRun: opts.dryRun ?? false,
+        onProgress: (msg) => console.log(msg),
+      });
+
+      if (!result.success) {
+        console.error(`\n${result.message}`);
+        if (result.errors.length > 0) {
+          console.error("\nErrors:");
+          for (const err of result.errors) {
+            console.error(`  - ${err}`);
+          }
+        }
+        process.exit(1);
+      }
+
+      console.log(`\n${result.message}`);
+    });
+}

--- a/packages/devac-cli/src/index.ts
+++ b/packages/devac-cli/src/index.ts
@@ -30,6 +30,7 @@ import {
   registerQueryCommand,
   registerRulesCommand,
   registerStatusCommand,
+  registerSyncCommand,
   registerTestCommand,
   registerTypecheckCommand,
   registerValidateCommand,
@@ -91,6 +92,9 @@ registerWorkflowCommand(program);
 
 // Doctor command (system health checks)
 registerDoctorCommand(program);
+
+// Sync command (analyze + register workflow)
+registerSyncCommand(program);
 
 // Default action: show status one-liner when no command is provided
 program.action(async () => {


### PR DESCRIPTION
## Summary

Add new top-level `devac sync` command that becomes the primary workflow for ensuring workspace seeds are analyzed and repos are registered.

**Closes #52**

## Changes

- **New `devac sync` command** - combines analyze + register in one step
  - `devac sync` - Analyze + register (optimized with --if-changed)
  - `devac sync --force` - Full reanalysis
  - `devac sync --analyze-only` - Only analyze, don't register
  - `devac sync --register-only` - Only register, skip analysis
  - `devac sync --dry-run` - Show what would be done

- **Breaking: Simplified `devac hub register`** - no longer auto-analyzes packages
  - Users should use `devac sync` for the combined workflow
  - `register` is now pure registration only

- **Updated status "Next Steps"** - now recommends `devac sync` instead of `hub register --all`

## Test plan

- [x] Build passes
- [x] All 315 tests pass (including 6 new sync command tests)
- [x] Lint passes
- [ ] Manual testing: `devac sync --dry-run` in workspace

## Changeset

Included: `.changeset/add-sync-command.md` (minor bump for @pietgk/devac-cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)