### PR TITLE
fix(devac-worktree): support full issue ID format in clean and resume commands

### DIFF
--- a/.changeset/fix-issue-parsing.md
+++ b/.changeset/fix-issue-parsing.md
@@ -1,0 +1,12 @@
+---
+"@pietgk/devac-worktree": patch
+---
+
+Fix issue ID parsing in clean and resume commands
+
+- Both `clean` and `resume` commands now accept full issue ID format (e.g., `ghvivief-62`) in addition to numeric format (`62`)
+- Added pre-checks for worktree cleanliness before clean operation
+- Added `--skip-pr-check` flag to skip only PR merged validation
+- Added `--yes` / `-y` flag to skip confirmation prompts
+- Added `checkWorktreeStatus()` function to detect modified/untracked files
+- Improved error messages with actionable suggestions


### PR DESCRIPTION
## Summary

- Fix `clean` and `resume` commands to accept full issue ID format (`ghvivief-62`) in addition to numeric format (`62`)
- Add pre-checks for worktree cleanliness before clean operations
- Improve UX with better error messages and confirmation prompts

## Changes

### `packages/devac-worktree/src/index.ts`
- Updated `resume` command to use `parseIssueArg()` instead of `Number.parseInt()`
- Updated `clean` command to use `parseIssueArg()` instead of `Number.parseInt()`
- Added `--skip-pr-check` flag to clean command
- Added `--yes` / `-y` flag to clean command

### `packages/devac-worktree/src/commands/clean.ts`
- Added `checkWorktreeStatus()` pre-check before removal
- Added confirmation prompt for dirty worktrees
- Improved error messages with actionable suggestions
- Added support for `skipPrCheck` and `yes` options

### `packages/devac-worktree/src/worktree.ts`
- Added `checkWorktreeStatus()` function to detect modified/untracked files

### `packages/devac-worktree/__tests__/worktree.test.ts`
- Added 6 tests for `checkWorktreeStatus()` function

## Test Plan

- [x] All 79 tests pass in devac-worktree package
- [x] Typecheck passes
- [x] Lint passes
- [x] Changeset included

## Usage Examples

```bash
# These now all work:
devac-worktree clean ghvivief-62   # Full format
devac-worktree clean 62            # Numeric format
devac-worktree resume ghvivief-62  # Full format
devac-worktree resume 62           # Numeric format

# New options:
devac-worktree clean 62 --force           # Skip PR check + force remove
devac-worktree clean 62 --skip-pr-check   # Skip only PR check
devac-worktree clean 62 --yes             # Skip confirmation prompts
```

Fixes #63

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)