### PR TITLE
docs: fix documentation inconsistencies

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -23,6 +23,9 @@ Version 2.3 evolved into v3.0, which added:
 - Updated issueId format (ghapi-123 → gh:mindler/api:123)
 - Refined workspace topology concepts
 - Improved Effect taxonomy
+- Developer-maintained effects workflow (ADR-0023)
+- Rules engine and C4 diagram generation
+- Unified diagnostics model (ADR-0018)
 
 ## Why Archive?
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1021,7 +1021,7 @@ Examples:
 - Code analysis: `find_symbol`, `get_dependencies`, `get_dependents`, `get_file_symbols`, `get_affected`, `get_call_graph`, `query_sql`
 - Context discovery: `get_context`, `list_repos`
 - Validation: `get_validation_errors`, `get_validation_summary`, `get_validation_counts`
-- Unified feedback: `get_all_feedback`, `get_feedback_summary`, `get_feedback_counts`
+- Unified diagnostics: `get_all_diagnostics`, `get_diagnostics_summary`, `get_diagnostics_counts`
 
 ## Context Commands
 
@@ -1723,7 +1723,7 @@ The `--hub` and `--package` flags are mutually exclusive. Hub mode is the defaul
 - Code analysis: `find_symbol`, `get_dependencies`, `get_dependents`, `get_file_symbols`, `get_affected`, `get_call_graph`, `query_sql`
 - Context discovery: `get_context`, `list_repos`
 - Validation: `get_validation_errors`, `get_validation_summary`, `get_validation_counts`
-- Unified feedback: `get_all_feedback`, `get_feedback_summary`, `get_feedback_counts`
+- Unified diagnostics: `get_all_diagnostics`, `get_diagnostics_summary`, `get_diagnostics_counts`
 
 See [MCP Server documentation](./mcp-server.md) for full tool reference.
 

--- a/docs/implementation/roadmap.md
+++ b/docs/implementation/roadmap.md
@@ -468,7 +468,7 @@ See [ADR-0017: Validation Hub Cache](../adr/0017-validation-hub-cache.md) for im
 |-----------|--------|-------------|
 | Feedback Model | ✅ Done | Unified model for validation, CI, issues, reviews |
 | PR Reviews Sync | ✅ Done | Extract and store PR review comments |
-| MCP Tools | ✅ Done | `get_all_feedback`, `get_feedback_summary`, `get_feedback_counts` |
+| MCP Tools | ✅ Done | `get_all_diagnostics`, `get_diagnostics_summary`, `get_diagnostics_counts` |
 | Severity Levels | ✅ Done | critical, error, warning, suggestion, note |
 | Category Grouping | ✅ Done | compilation, linting, testing, ci-check, task, feedback, code-review |
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -297,9 +297,9 @@ Get total counts of validation errors and warnings across all repositories. Only
 **Response:**
 Returns `{ "errors": 18, "warnings": 7 }`.
 
-### get_all_feedback
+### get_all_diagnostics
 
-Get all feedback (validation errors, CI failures, GitHub issues, PR reviews) from a unified view. Use this to answer "What do I need to fix?" across all feedback types. Only available in hub mode.
+Get all diagnostics (validation errors, CI failures, GitHub issues, PR reviews) from a unified view. Use this to answer "What do I need to fix?" across all diagnostics types. Only available in hub mode.
 
 **Parameters:**
 - `repo_id` (string, optional): Filter by repository ID
@@ -313,7 +313,7 @@ Get all feedback (validation errors, CI failures, GitHub issues, PR reviews) fro
 **Example:**
 ```json
 {
-  "name": "get_all_feedback",
+  "name": "get_all_diagnostics",
   "arguments": {
     "severity": ["error", "critical"],
     "source": ["tsc", "eslint"],
@@ -322,9 +322,9 @@ Get all feedback (validation errors, CI failures, GitHub issues, PR reviews) fro
 }
 ```
 
-### get_feedback_summary
+### get_diagnostics_summary
 
-Get a summary of all feedback grouped by source, severity, category, or repository. Only available in hub mode.
+Get a summary of all diagnostics grouped by source, severity, category, or repository. Only available in hub mode.
 
 **Parameters:**
 - `groupBy` (string, required): How to group counts ("repo", "source", "severity", or "category")
@@ -332,7 +332,7 @@ Get a summary of all feedback grouped by source, severity, category, or reposito
 **Example:**
 ```json
 {
-  "name": "get_feedback_summary",
+  "name": "get_diagnostics_summary",
   "arguments": {
     "groupBy": "category"
   }
@@ -342,9 +342,9 @@ Get a summary of all feedback grouped by source, severity, category, or reposito
 **Response:**
 Returns grouped counts like `{ "compilation": 5, "linting": 3, "testing": 2 }`.
 
-### get_feedback_counts
+### get_diagnostics_counts
 
-Get total counts of feedback by severity level. Only available in hub mode.
+Get total counts of diagnostics by severity level. Only available in hub mode.
 
 **Parameters:**
 - None
@@ -352,7 +352,7 @@ Get total counts of feedback by severity level. Only available in hub mode.
 **Example:**
 ```json
 {
-  "name": "get_feedback_counts",
+  "name": "get_diagnostics_counts",
   "arguments": {}
 }
 ```

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -8,7 +8,7 @@ This directory contains the conceptual architecture for DevAC — the aspiration
 
 | Document | Purpose |
 |----------|---------|
-| [concepts.md](./concepts.md) | **Quick reference**: Three Pillars, terminology, status command, glossary |
+| [concepts.md](./concepts.md) | **Quick reference**: Four Pillars, terminology, status command, glossary |
 | [foundation.md](./foundation.md) | Core concepts: Effect Handler pattern, Seeds, Vision↔View loop, Human/LLM/System division |
 | [foundation-visual.md](./foundation-visual.md) | Visual companion with Mermaid diagrams illustrating the concepts |
 | [foundation-impl-guide.md](./foundation-impl-guide.md) | Guidance on how to implement the foundation concepts |
@@ -24,13 +24,14 @@ This directory contains the conceptual architecture for DevAC — the aspiration
 
 ## Key Concepts
 
-### Three Pillars of DevAC
+### Four Pillars of DevAC
 
 | Pillar | What It Does | Produces |
 |--------|--------------|----------|
 | **Infra** | Runs DevAC itself | DevAC Health |
 | **Validators** | Check code health | Diagnostics |
 | **Extractors** | Extract queryable data | Seeds |
+| **Workflow** | Orchestrates development flow | Issue→PR→Merge automation |
 
 Plus **Analytics** which uses Seeds + Diagnostics to answer questions.
 

--- a/docs/vision/foundation-impl-guide.md
+++ b/docs/vision/foundation-impl-guide.md
@@ -50,13 +50,13 @@ Phase 4: Iterative Refinement
 | Universal AST extraction | ✅ Done | TypeScript, Python, C# parsers |
 | Seeds (Parquet) | ✅ Done | nodes, edges, external_refs tables |
 | Hub federation | ✅ Done | Cross-repo queries via DuckDB |
-| MCP server | ✅ Done | 12 tools for LLM querying |
+| MCP server | ✅ Done | 22 tools for LLM querying |
 | Worktree workflow | ✅ Done | Issue-based git worktrees |
 | Incremental updates | ✅ Done | Watch mode, delta storage |
 | Context discovery | ✅ Done | Sibling repos, issue grouping |
 | Validation coordinator | ✅ Done | Type-check, lint, test integration |
 | **Workspace module** | ✅ Done | Multi-repo orchestration (Phase 1) |
-| CLI | ✅ Done | 17+ commands |
+| CLI | ✅ Done | 40+ commands |
 
 ### Phase 1: Workspace Discovery + Unified Watcher (COMPLETE)
 
@@ -97,9 +97,11 @@ Source Files → [devac watch] → Seeds → [workspace watch] → Hub → Cross
 | Capability | Priority | Status | Notes |
 |------------|----------|--------|-------|
 | Effect Store (full) | Low | Not started | Seeds provide MVP; full log optional |
-| Effect Schemas | Medium | Not started | Zod schemas for effect types |
-| Rules Engine | Medium | Not started | Pattern matching for aggregation |
-| Vision→View Pipeline | Medium | Partial | Diagram generation from seeds |
+| Effect Schemas | Medium | ✅ Done | Zod schemas in `types/effects.ts` |
+| Effects Extraction | Medium | ✅ Done | Developer-maintained via `devac effects` commands (see [ADR-0023](../adr/0023-developer-maintained-effects.md)) |
+| Rules Engine | Medium | ✅ Done | Pattern matching for aggregation (see [rules-engine.md](../implementation/rules-engine.md)) |
+| Vision→View Pipeline | Medium | ✅ Done | C4 diagram generation via `devac c4` commands |
+| Eval Framework | Medium | ✅ Done | Answer quality evaluation (see [ADR-0022](../adr/0022-eval-framework.md)) |
 | Runtime Extraction | Low | Not started | Test-time instrumentation |
 | GitHub Webhooks | Medium | Not started | Real-time PR/CI events |
 | Vector Queries | Low | Not started | Semantic search over content |

--- a/docs/vision/validation.md
+++ b/docs/vision/validation.md
@@ -220,7 +220,7 @@ LLMs access the same data via MCP:
 
 | Document | Relationship |
 |----------|--------------|
-| [Concepts](./concepts.md) | Three Pillars, terminology, glossary |
+| [Concepts](./concepts.md) | Four Pillars, terminology, glossary |
 | [ADR-0017: Validation Hub Cache](../adr/0017-validation-hub-cache.md) | Why DuckDB for validation cache |
 | [ADR-0018: Unified Diagnostics Model](../adr/0018-unified-diagnostics-model.md) | Schema design for unified diagnostics |
 | [ADR-0019: Coverage Validator](../adr/0019-coverage-validator.md) | Coverage as first-class diagnostic |


### PR DESCRIPTION
## Summary

Fixes documentation inconsistencies identified in #71:

- **Pillar terminology**: Updated "Three Pillars" → "Four Pillars" (adds Workflow as 4th pillar)
- **MCP tool naming**: Fixed `get_all_feedback` → `get_all_diagnostics` to match implementation
- **MCP tool count**: Updated 12 → 22 tools
- **CLI command count**: Updated 17+ → 40+ commands
- **Implementation status**: Marked Effects, Rules Engine, C4, Eval Framework as done
- **ADR references**: Added links to ADR-0022 and ADR-0023 in implementation guide
- **Archive README**: Added v3.0 features to version evolution

## Test plan

- [ ] Verify pillar count is consistent across all docs
- [ ] Verify MCP tool names match implementation
- [ ] Review updated implementation status table

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)