### PR TITLE
fix: skip performance tests in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,9 @@
 pnpm typecheck
-pnpm test
+
+# Run tests, excluding performance tests (they're flaky locally due to machine load variability)
+# Performance tests run in CI where the environment is controlled
+# See: https://github.com/pietgk/vivief/issues/98
+pnpm --filter @pietgk/devac-core test -- --exclude="__tests__/performance/**"
+pnpm --filter @pietgk/devac-cli test
+pnpm --filter @pietgk/devac-mcp test
+pnpm --filter @pietgk/devac-worktree test


### PR DESCRIPTION
## Summary

Skip performance tests during pre-push to prevent flaky failures blocking developer workflow.

- Exclude `__tests__/performance/**` from devac-core tests in pre-push
- Performance tests still run in CI where environment is controlled
- Added comment explaining why and linking to issue

Fixes #98

## Test plan

- [x] Verified pre-push hook excludes performance tests (36 test files instead of 37)
- [x] Verified all other tests still run (devac-cli, devac-mcp, devac-worktree)
- [x] CI will still run full test suite including performance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)