### PR TITLE
feat(hub): consolidate hub location to workspace-only mode

### DIFF
--- a/.changeset/consolidate-hub-location.md
+++ b/.changeset/consolidate-hub-location.md
@@ -1,0 +1,15 @@
+---
+"@pietgk/devac-cli": minor
+"@pietgk/devac-core": minor
+---
+
+Consolidate hub location to workspace-only mode
+
+**Breaking Change:** DevAC now requires a workspace context. The `--hub-dir` option has been removed from all CLI commands.
+
+- All hub operations now use `{workspace}/.devac` automatically
+- Removed `getDefaultHubDir()` fallback to `~/.devac`
+- Made `hubDir` required in `HubClient` constructor
+- Added helpful error message when not in a workspace context suggesting `devac workspace init`
+
+This change ensures consistent hub usage across CLI and MCP, preventing DuckDB corruption from multiple hub databases.

--- a/packages/devac-cli/src/commands/c4.ts
+++ b/packages/devac-cli/src/commands/c4.ts
@@ -6,7 +6,6 @@
  */
 
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import {
   type C4ContainerDiagram,
@@ -30,11 +29,8 @@ import {
   setupQueryContext,
 } from "@pietgk/devac-core";
 import type { Command } from "commander";
+import { getWorkspaceHubDir } from "../utils/workspace-discovery.js";
 import { formatOutput, formatTable } from "./output-formatter.js";
-
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
 
 /**
  * Check if a package has effects.parquet file
@@ -57,8 +53,6 @@ export interface C4CommandOptions {
   packagePath?: string;
   /** Use hub mode for federated queries */
   hub?: boolean;
-  /** Hub directory (default: ~/.devac) */
-  hubDir?: string;
   /** System name for diagrams */
   systemName?: string;
   /** System description */
@@ -266,7 +260,7 @@ async function getDomainEffects(options: C4CommandOptions) {
     const limitClause = options.limit ? `LIMIT ${options.limit}` : "LIMIT 5000";
 
     if (options.hub) {
-      const hubDir = options.hubDir || getDefaultHubDir();
+      const hubDir = await getWorkspaceHubDir();
       const hub = createCentralHub({ hubDir, readOnly: true });
 
       try {
@@ -576,7 +570,6 @@ export function registerC4Command(program: Command): void {
     .description("Generate C4 Context diagram (default command)")
     .option("-p, --package <path>", "Package path")
     .option("--hub", "Query all registered repos via Hub")
-    .option("--hub-dir <path>", "Hub directory", getDefaultHubDir())
     .option("-n, --name <name>", "System name", "System")
     .option("-d, --description <desc>", "System description")
     .option("-l, --limit <count>", "Maximum effects to process", "5000")
@@ -587,7 +580,6 @@ export function registerC4Command(program: Command): void {
       const result = await c4ContextCommand({
         packagePath,
         hub: options.hub,
-        hubDir: options.hubDir,
         systemName: options.name,
         systemDescription: options.description,
         limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
@@ -607,7 +599,6 @@ export function registerC4Command(program: Command): void {
     .description("Generate C4 Container diagram")
     .option("-p, --package <path>", "Package path")
     .option("--hub", "Query all registered repos via Hub")
-    .option("--hub-dir <path>", "Hub directory", getDefaultHubDir())
     .option("-n, --name <name>", "System name", "System")
     .option(
       "-g, --grouping <strategy>",
@@ -622,7 +613,6 @@ export function registerC4Command(program: Command): void {
       const result = await c4ContainersCommand({
         packagePath,
         hub: options.hub,
-        hubDir: options.hubDir,
         systemName: options.name,
         grouping: options.grouping as "directory" | "package" | "flat",
         limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
@@ -642,7 +632,6 @@ export function registerC4Command(program: Command): void {
     .description("Discover domain boundaries from effects")
     .option("-p, --package <path>", "Package path")
     .option("--hub", "Query all registered repos via Hub")
-    .option("--hub-dir <path>", "Hub directory", getDefaultHubDir())
     .option("-l, --limit <count>", "Maximum effects to process", "5000")
     .option("--json", "Output as JSON")
     .action(async (options) => {
@@ -650,7 +639,6 @@ export function registerC4Command(program: Command): void {
       const result = await c4DomainsCommand({
         packagePath,
         hub: options.hub,
-        hubDir: options.hubDir,
         limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
         json: options.json,
       });
@@ -667,7 +655,6 @@ export function registerC4Command(program: Command): void {
     .description("List external systems detected from effects")
     .option("-p, --package <path>", "Package path")
     .option("--hub", "Query all registered repos via Hub")
-    .option("--hub-dir <path>", "Hub directory", getDefaultHubDir())
     .option("-l, --limit <count>", "Maximum effects to process", "5000")
     .option("--json", "Output as JSON")
     .action(async (options) => {
@@ -675,7 +662,6 @@ export function registerC4Command(program: Command): void {
       const result = await c4ExternalsCommand({
         packagePath,
         hub: options.hub,
-        hubDir: options.hubDir,
         limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
         json: options.json,
       });

--- a/packages/devac-cli/src/commands/context.ts
+++ b/packages/devac-cli/src/commands/context.ts
@@ -5,8 +5,6 @@
  * Includes CI status and LLM review subcommands.
  */
 
-import * as os from "node:os";
-import * as path from "node:path";
 import {
   CentralHub,
   buildReviewPrompt,
@@ -42,13 +40,7 @@ import type {
   ReviewsResult,
 } from "@pietgk/devac-core";
 import type { Command } from "commander";
-
-/**
- * Get default hub directory
- */
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
+import { getWorkspaceHubDir } from "../utils/workspace-discovery.js";
 
 export interface ContextOptions {
   /** Current working directory */
@@ -146,7 +138,7 @@ export async function contextCICommand(options: ContextCIOptions): Promise<Conte
     // Optionally sync to Hub
     let syncResult: CISyncResult | undefined;
     if (options.syncToHub) {
-      const hubDir = getDefaultHubDir();
+      const hubDir = await getWorkspaceHubDir();
       const hub = new CentralHub({ hubDir });
       try {
         await hub.init();
@@ -276,7 +268,7 @@ export async function contextIssuesCommand(
     // Optionally sync to Hub
     let syncResult: IssueSyncResult | undefined;
     if (options.syncToHub) {
-      const hubDir = getDefaultHubDir();
+      const hubDir = await getWorkspaceHubDir();
       const hub = new CentralHub({ hubDir });
       try {
         await hub.init();
@@ -374,7 +366,7 @@ export async function contextReviewsCommand(
     // Optionally sync to Hub
     let syncResult: ReviewSyncResult | undefined;
     if (options.syncToHub) {
-      const hubDir = getDefaultHubDir();
+      const hubDir = await getWorkspaceHubDir();
       const hub = new CentralHub({ hubDir });
       try {
         await hub.init();

--- a/packages/devac-cli/src/commands/deps.ts
+++ b/packages/devac-cli/src/commands/deps.ts
@@ -5,7 +5,6 @@
  * Based on MCP get_dependencies tool.
  */
 
-import * as os from "node:os";
 import * as path from "node:path";
 import {
   DuckDBPool,
@@ -15,11 +14,8 @@ import {
   queryMultiplePackages,
 } from "@pietgk/devac-core";
 import type { Command } from "commander";
+import { getWorkspaceHubDir } from "../utils/workspace-discovery.js";
 import { formatDependencies, formatOutput } from "./output-formatter.js";
-
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
 
 /**
  * Options for deps command
@@ -31,8 +27,6 @@ export interface DepsCommandOptions {
   packagePath?: string;
   /** Use hub mode for federated queries */
   hub?: boolean;
-  /** Hub directory (default: ~/.devac) */
-  hubDir?: string;
   /** Filter by edge type (CALLS, IMPORTS, EXTENDS, etc.) */
   edgeType?: string;
   /** Maximum results to return */
@@ -74,7 +68,7 @@ export async function depsCommand(options: DepsCommandOptions): Promise<DepsComm
 
     if (options.hub) {
       // Hub mode: query all registered repos
-      const hubDir = options.hubDir || getDefaultHubDir();
+      const hubDir = await getWorkspaceHubDir();
       const hub = createCentralHub({ hubDir, readOnly: true });
 
       try {
@@ -182,7 +176,6 @@ export function registerDepsCommand(program: Command): void {
     .option("-p, --package <path>", "Package path", process.cwd())
     .option("-t, --type <type>", "Filter by edge type (CALLS, IMPORTS, etc.)")
     .option("--hub", "Query all registered repos via Hub")
-    .option("--hub-dir <path>", "Hub directory", getDefaultHubDir())
     .option("-l, --limit <count>", "Maximum results", "100")
     .option("--json", "Output as JSON")
     .action(async (entityId, options) => {
@@ -190,7 +183,6 @@ export function registerDepsCommand(program: Command): void {
         entityId,
         packagePath: options.package ? path.resolve(options.package) : undefined,
         hub: options.hub,
-        hubDir: options.hubDir,
         edgeType: options.type,
         limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
         json: options.json,

--- a/packages/devac-cli/src/commands/diagnostics.ts
+++ b/packages/devac-cli/src/commands/diagnostics.ts
@@ -6,18 +6,13 @@
  * @see docs/vision/concepts.md for the Three Pillars model
  */
 
-import * as os from "node:os";
-import * as path from "node:path";
 import type { Command } from "commander";
+import { getWorkspaceHubDir } from "../utils/workspace-discovery.js";
 import {
   type HubDiagnosticsCommandOptions,
   type HubDiagnosticsCommandResult,
   hubDiagnosticsCommand,
 } from "./hub-diagnostics.js";
-
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
 
 // Re-export types
 export type DiagnosticsCommandOptions = HubDiagnosticsCommandOptions;
@@ -39,7 +34,6 @@ export function registerDiagnosticsCommand(program: Command): void {
   program
     .command("diagnostics")
     .description("Query all diagnostics from the hub (validation + workflow)")
-    .option("--hub-dir <path>", "Hub directory", getDefaultHubDir())
     .option("--repo <id>", "Filter by repository")
     .option(
       "--source <source>",
@@ -53,8 +47,9 @@ export function registerDiagnosticsCommand(program: Command): void {
     .option("-l, --limit <count>", "Maximum results", "100")
     .option("--json", "Output as JSON")
     .action(async (options) => {
+      const hubDir = await getWorkspaceHubDir();
       const result = await diagnosticsCommand({
-        hubDir: options.hubDir,
+        hubDir,
         repoId: options.repo,
         source: options.source,
         severity: options.severity,

--- a/packages/devac-cli/src/commands/hub-diagnostics.ts
+++ b/packages/devac-cli/src/commands/hub-diagnostics.ts
@@ -5,8 +5,6 @@
  * Based on MCP get_all_diagnostics tool.
  */
 
-import * as os from "node:os";
-import * as path from "node:path";
 import {
   type DiagnosticsCategory,
   type DiagnosticsFilter,
@@ -17,16 +15,12 @@ import {
 } from "@pietgk/devac-core";
 import { formatDiagnostics, formatOutput } from "./output-formatter.js";
 
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
-
 /**
  * Options for hub-diagnostics command
  */
 export interface HubDiagnosticsCommandOptions {
-  /** Hub directory (default: ~/.devac) */
-  hubDir?: string;
+  /** Hub directory (required - from workspace) */
+  hubDir: string;
   /** Filter by repository ID */
   repoId?: string;
   /** Filter by source(s) */
@@ -72,9 +66,8 @@ export async function hubDiagnosticsCommand(
   options: HubDiagnosticsCommandOptions
 ): Promise<HubDiagnosticsCommandResult> {
   const startTime = Date.now();
-  const hubDir = options.hubDir || getDefaultHubDir();
   // Use HubClient (delegates to MCP if running, otherwise direct access)
-  const client = createHubClient({ hubDir });
+  const client = createHubClient({ hubDir: options.hubDir });
 
   try {
     const filter: DiagnosticsFilter = {

--- a/packages/devac-cli/src/commands/hub-errors.ts
+++ b/packages/devac-cli/src/commands/hub-errors.ts
@@ -5,21 +5,15 @@
  * Based on MCP get_validation_errors tool.
  */
 
-import * as os from "node:os";
-import * as path from "node:path";
 import { type ValidationError, type ValidationFilter, createHubClient } from "@pietgk/devac-core";
 import { formatOutput, formatValidationIssues } from "./output-formatter.js";
-
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
 
 /**
  * Options for hub-errors command
  */
 export interface HubErrorsCommandOptions {
-  /** Hub directory (default: ~/.devac) */
-  hubDir?: string;
+  /** Hub directory (required - from workspace) */
+  hubDir: string;
   /** Filter by repository ID */
   repoId?: string;
   /** Filter by severity (error, warning) */
@@ -59,9 +53,8 @@ export async function hubErrorsCommand(
   options: HubErrorsCommandOptions
 ): Promise<HubErrorsCommandResult> {
   const startTime = Date.now();
-  const hubDir = options.hubDir || getDefaultHubDir();
   // Use HubClient (delegates to MCP if running, otherwise direct access)
-  const client = createHubClient({ hubDir });
+  const client = createHubClient({ hubDir: options.hubDir });
 
   try {
     const filter: ValidationFilter = {

--- a/packages/devac-cli/src/commands/hub-init.ts
+++ b/packages/devac-cli/src/commands/hub-init.ts
@@ -131,14 +131,6 @@ export async function hubInit(options: HubInitOptions): Promise<HubInitResult> {
 }
 
 /**
- * Get the default hub directory path
- */
-export function getDefaultHubDir(): string {
-  const home = process.env.HOME || process.env.USERPROFILE || "";
-  return path.join(home, ".devac");
-}
-
-/**
  * Register the hub command with all subcommands
  */
 export function registerHubCommand(program: Command): void {
@@ -148,11 +140,10 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("init")
     .description("Initialize the workspace hub")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--force", "Force reinitialization")
     .action(async (options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubInit({
           hubDir,
           force: options.force,
@@ -177,11 +168,10 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("register [path]")
     .description("Register a repository with the hub (use 'devac sync' to analyze + register)")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--all", "Register all repositories in workspace")
     .action(async (repoPath, options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const resolvedPath = repoPath ? path.resolve(repoPath) : process.cwd();
         const result = await hubRegister({
           hubDir,
@@ -203,10 +193,9 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("unregister <repoId>")
     .description("Unregister a repository from the hub")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
-    .action(async (repoId, options) => {
+    .action(async (repoId) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubUnregister({ hubDir, repoId });
         displayCommandResult(result);
       } catch (err) {
@@ -222,12 +211,11 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("list")
     .description("List registered repositories")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--json", "Output as JSON")
     .option("-v, --verbose", "Verbose output")
     .action(async (options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubList({
           hubDir,
           json: options.json,
@@ -258,11 +246,10 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("status")
     .description("Show hub status")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--json", "Output as JSON")
     .action(async (options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubStatus({ hubDir });
         if (!result.success) {
           displayCommandResult(result);
@@ -286,11 +273,10 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("refresh [repoId]")
     .description("Refresh repository manifests")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--force", "Force regenerate all manifests")
     .action(async (repoId, options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubRefresh({
           hubDir,
           repoId,
@@ -349,7 +335,6 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("errors")
     .description("Query validation errors from the hub")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--repo <id>", "Filter by repository")
     .option("--severity <level>", "Filter by severity (error, warning)")
     .option("--source <source>", "Filter by source (tsc, eslint, test)")
@@ -358,7 +343,7 @@ export function registerHubCommand(program: Command): void {
     .option("--json", "Output as JSON")
     .action(async (options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubErrorsCommand({
           hubDir,
           repoId: options.repo,
@@ -404,7 +389,6 @@ export function registerHubCommand(program: Command): void {
     .command("diagnostics")
     .alias("feedback")
     .description("Query unified diagnostics from the hub")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--repo <id>", "Filter by repository")
     .option("--source <source>", "Filter by source")
     .option("--severity <level>", "Filter by severity")
@@ -416,7 +400,7 @@ export function registerHubCommand(program: Command): void {
     .option("--json", "Output as JSON")
     .action(async (options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubDiagnosticsCommand({
           hubDir,
           repoId: options.repo,
@@ -464,12 +448,11 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("summary <type>")
     .description("Get summary/counts (validation, diagnostics, counts)")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--group-by <field>", "Group by field")
     .option("--json", "Output as JSON")
     .action(async (type, options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubSummaryCommand({
           hubDir,
           type: type as "validation" | "diagnostics" | "counts",
@@ -511,12 +494,11 @@ export function registerHubCommand(program: Command): void {
   hub
     .command("query <sql>")
     .description("Execute SQL query across all registered repositories")
-    .option("--hub-dir <path>", "Hub directory (auto-detected from workspace)")
     .option("--branch <branch>", "Branch to query (default: base)", "base")
     .option("--json", "Output as JSON")
     .action(async (sql, options) => {
       try {
-        const hubDir = options.hubDir || (await getWorkspaceHubDir());
+        const hubDir = await getWorkspaceHubDir();
         const result = await hubQueryCommand({
           hubDir,
           sql,

--- a/packages/devac-cli/src/commands/hub-summary.ts
+++ b/packages/devac-cli/src/commands/hub-summary.ts
@@ -5,8 +5,6 @@
  * Based on MCP get_validation_summary and get_diagnostics_summary tools.
  */
 
-import * as os from "node:os";
-import * as path from "node:path";
 import {
   type DiagnosticsSummary,
   type ValidationSummary,
@@ -14,16 +12,12 @@ import {
 } from "@pietgk/devac-core";
 import { formatOutput, formatSummary } from "./output-formatter.js";
 
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
-
 /**
  * Options for hub-summary command
  */
 export interface HubSummaryCommandOptions {
-  /** Hub directory (default: ~/.devac) */
-  hubDir?: string;
+  /** Hub directory (required - from workspace) */
+  hubDir: string;
   /** Summary type: validation, diagnostics, or counts */
   type: "validation" | "diagnostics" | "counts";
   /** Group by field (for validation/diagnostics) */
@@ -69,9 +63,8 @@ export async function hubSummaryCommand(
   options: HubSummaryCommandOptions
 ): Promise<HubSummaryCommandResult> {
   const startTime = Date.now();
-  const hubDir = options.hubDir || getDefaultHubDir();
   // Use HubClient (delegates to MCP if running, otherwise direct access)
-  const client = createHubClient({ hubDir });
+  const client = createHubClient({ hubDir: options.hubDir });
 
   try {
     let output: string;

--- a/packages/devac-cli/src/commands/hub-sync.ts
+++ b/packages/devac-cli/src/commands/hub-sync.ts
@@ -4,8 +4,6 @@
  * Syncs external diagnostics (CI status, issues, reviews) to the Hub's unified_diagnostics table.
  */
 
-import * as os from "node:os";
-import * as path from "node:path";
 import {
   CentralHub,
   discoverContext,
@@ -17,13 +15,7 @@ import {
   syncReviewsToHub,
 } from "@pietgk/devac-core";
 import type { CISyncResult, IssueSyncResult, ReviewSyncResult } from "@pietgk/devac-core";
-
-/**
- * Get default hub directory
- */
-function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
-}
+import { getWorkspaceHubDir } from "../utils/workspace-discovery.js";
 
 /**
  * Options for hub sync command
@@ -72,7 +64,7 @@ export interface HubSyncResult {
  * Sync feedback to the Hub
  */
 export async function hubSyncCommand(options: HubSyncOptions): Promise<HubSyncResult> {
-  const hubDir = getDefaultHubDir();
+  const hubDir = await getWorkspaceHubDir();
   const hub = new CentralHub({ hubDir });
 
   try {

--- a/packages/devac-cli/src/commands/watch.ts
+++ b/packages/devac-cli/src/commands/watch.ts
@@ -7,7 +7,6 @@
 
 import { EventEmitter } from "node:events";
 import * as fs from "node:fs/promises";
-import * as os from "node:os";
 import * as path from "node:path";
 import {
   type CrossRepoDetector,
@@ -452,8 +451,10 @@ class WatchControllerImpl implements WatchController {
    * Write a cross-repo need notification to file
    */
   private async writeNotification(need: WatchCrossRepoNeedEvent): Promise<void> {
+    // Use notifications path from options, or default to workspace/.devac/notifications.log
     const notificationsPath =
-      this.options.notificationsPath || path.join(os.homedir(), ".devac", "notifications.log");
+      this.options.notificationsPath ||
+      path.join(this.options.packagePath, "..", ".devac", "notifications.log");
 
     try {
       // Ensure directory exists

--- a/packages/devac-cli/src/utils/workspace-discovery.ts
+++ b/packages/devac-cli/src/utils/workspace-discovery.ts
@@ -25,7 +25,9 @@ export async function getWorkspaceHubDir(startDir?: string): Promise<string> {
   const hubDir = await coreFindWorkspaceHubDir(startDir);
   if (!hubDir) {
     throw new Error(
-      "Not in a workspace. Run from a workspace directory or a repository within a workspace."
+      "Not in a workspace. Run from a workspace directory or a repository within a workspace.\n\n" +
+        "To initialize the current directory as a workspace, run:\n" +
+        "  devac workspace init"
     );
   }
   return hubDir;

--- a/packages/devac-core/src/effects/mapping-loader.ts
+++ b/packages/devac-core/src/effects/mapping-loader.ts
@@ -183,9 +183,9 @@ function extractMappingArray<T>(content: string, arrayName: string): T[] {
 
   // Match object literals
   const objectPattern = /\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}/g;
-  let objectMatch: RegExpExecArray | null;
+  let objectMatch = objectPattern.exec(arrayContent);
 
-  while ((objectMatch = objectPattern.exec(arrayContent)) !== null) {
+  while (objectMatch !== null) {
     try {
       const obj = parseObjectLiteral<T>(objectMatch[1] ?? "");
       if (obj) {
@@ -194,6 +194,7 @@ function extractMappingArray<T>(content: string, arrayName: string): T[] {
     } catch {
       // Skip malformed objects
     }
+    objectMatch = objectPattern.exec(arrayContent);
   }
 
   return objects;
@@ -209,9 +210,9 @@ function parseObjectLiteral<T>(content: string): T | null {
 
     // Match pattern: key: value or "key": value
     const propPattern = /["']?(\w+)["']?\s*:\s*(?:"([^"]*?)"|'([^']*?)'|(\w+)|(\d+))/g;
-    let propMatch: RegExpExecArray | null;
+    let propMatch = propPattern.exec(content);
 
-    while ((propMatch = propPattern.exec(content)) !== null) {
+    while (propMatch !== null) {
       const key = propMatch[1];
       const value = propMatch[2] ?? propMatch[3] ?? propMatch[4] ?? propMatch[5];
 
@@ -227,6 +228,7 @@ function parseObjectLiteral<T>(content: string): T | null {
           obj[key] = value;
         }
       }
+      propMatch = propPattern.exec(content);
     }
 
     return Object.keys(obj).length > 0 ? (obj as T) : null;

--- a/packages/devac-core/src/hub/hub-client.ts
+++ b/packages/devac-core/src/hub/hub-client.ts
@@ -31,7 +31,6 @@ import {
   type HubResponse,
   IPC_CONNECT_TIMEOUT_MS,
   IPC_TIMEOUT_MS,
-  getDefaultHubDir,
   getSocketPath,
 } from "./ipc-protocol.js";
 
@@ -40,8 +39,8 @@ import {
 // ─────────────────────────────────────────────────────────────
 
 export interface HubClientOptions {
-  /** Hub directory (defaults to ~/.devac) */
-  hubDir?: string;
+  /** Hub directory (required - use findWorkspaceHubDir to get it) */
+  hubDir: string;
   /** Timeout for IPC operations (ms) */
   timeout?: number;
 }
@@ -55,8 +54,8 @@ export class HubClient {
   private socketPath: string;
   private timeout: number;
 
-  constructor(options: HubClientOptions = {}) {
-    this.hubDir = options.hubDir ?? getDefaultHubDir();
+  constructor(options: HubClientOptions) {
+    this.hubDir = options.hubDir;
     this.socketPath = getSocketPath(this.hubDir);
     this.timeout = options.timeout ?? IPC_TIMEOUT_MS;
   }
@@ -378,6 +377,6 @@ export class HubClient {
 // Factory Function
 // ─────────────────────────────────────────────────────────────
 
-export function createHubClient(options?: HubClientOptions): HubClient {
+export function createHubClient(options: HubClientOptions): HubClient {
   return new HubClient(options);
 }

--- a/packages/devac-core/src/hub/index.ts
+++ b/packages/devac-core/src/hub/index.ts
@@ -58,7 +58,6 @@ export {
   IPC_TIMEOUT_MS,
   IPC_CONNECT_TIMEOUT_MS,
   getSocketPath,
-  getDefaultHubDir,
   type HubMethod,
   type HubRequest,
   type HubResponse,

--- a/packages/devac-core/src/hub/ipc-protocol.ts
+++ b/packages/devac-core/src/hub/ipc-protocol.ts
@@ -5,7 +5,6 @@
  * CLI commands communicate with MCP via Unix socket IPC.
  */
 
-import * as os from "node:os";
 import * as path from "node:path";
 
 // ─────────────────────────────────────────────────────────────
@@ -106,13 +105,6 @@ export const HubErrorCode = {
  */
 export function getSocketPath(hubDir: string): string {
   return path.join(hubDir, HUB_SOCKET_NAME);
-}
-
-/**
- * Get the default hub directory (~/.devac)
- */
-export function getDefaultHubDir(): string {
-  return path.join(os.homedir(), ".devac");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Consolidated hub location to workspace-only mode (`{workspace}/.devac`)
- Removed `getDefaultHubDir()` fallback to `~/.devac` from devac-core
- Made `hubDir` required in `HubClient` constructor
- Removed `--hub-dir` option from all CLI commands
- Added helpful error message when not in workspace suggesting `devac workspace init`

**Breaking Change:** DevAC now requires a workspace context. This ensures consistent hub usage across CLI and MCP, preventing DuckDB corruption from multiple hub databases.

## Test plan

- [x] All 573 tests pass
- [x] Typecheck passes
- [x] Lint passes (no errors or warnings)
- [ ] Manual test: run command outside workspace → shows helpful error
- [ ] Manual test: run command inside workspace → works correctly

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)