### PR TITLE
fix(rules): fix regex patterns and add Kysely/tRPC rules

### DIFF
--- a/.changeset/fix-rules-engine-regex.md
+++ b/.changeset/fix-rules-engine-regex.md
@@ -1,0 +1,13 @@
+---
+"@pietgk/devac-core": patch
+---
+
+Fix rules engine regex patterns and add missing technology rules
+
+- Remove `\(` from SQL patterns that prevented matching (callee names don't include parentheses)
+- Add Kysely ORM rules for database operations (selectFrom, insertInto, updateTable, deleteFrom)
+- Add tRPC API rules for procedure definitions (procedure.mutation, procedure.query)
+- Remove overly restrictive `isExternal: true` from AWS service rules (DynamoDB, S3, SQS, SNS, etc.)
+- Update documentation with correct patterns and new rules
+
+Fixes #105


### PR DESCRIPTION
## Summary

- Fix regex patterns in builtin-rules.ts that included `\(` (callee names don't include parentheses)
- Add Kysely ORM rules for database operations (selectFrom, insertInto, updateTable, deleteFrom)
- Add tRPC API rules for procedure definitions (procedure.mutation, procedure.query)
- Remove overly restrictive `isExternal: true` from AWS service rules

## Changes

### Bug Fixes
- Remove `\(` from SQL read/write patterns that prevented any matches
- Rules now correctly use `$` end anchor instead of `\(`

### New Rules
- `db-kysely-read`: Kysely query operations (selectFrom, selectAll, executeTakeFirst, executeTakeFirstOrThrow)
- `db-kysely-write`: Kysely write operations (insertInto, updateTable, deleteFrom)
- `api-trpc-mutation`: tRPC mutation definitions (procedure.mutation)
- `api-trpc-query`: tRPC query definitions (procedure.query)
- `api-trpc-procedure`: tRPC procedure definitions (.procedure)

### Relaxed Restrictions
Removed `isExternal: true` from 12 rules where the callee pattern is already specific enough:
- DynamoDB (read/write)
- Stripe (charge/refund/subscription)
- Cognito
- SQS (send/receive)
- SNS (publish)
- EventBridge
- S3 (put/get)
- Datadog

## Test Plan

- [x] Added 12 new unit tests for all rule changes
- [x] All 1318 tests passing
- [x] Tested against Mindler workspace: 313 database operations now classified (was 0)

## Documentation

- [x] Updated `docs/implementation/rules-engine.md` with correct patterns
- [x] Added Kysely and tRPC rules to documentation
- [x] Created changeset for patch release

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)