### PR TITLE
docs: update ADR dates and add ramblings notes

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,29 +10,29 @@ An Architecture Decision Record captures an important architectural decision mad
 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
-| [0001](0001-replace-neo4j-with-duckdb.md) | Replace Neo4j with DuckDB | Accepted | 2024-12 |
-| [0002](0002-per-package-partitioning.md) | Per-Package Partitioning | Accepted | 2024-12 |
-| [0003](0003-entity-id-scoped-names.md) | Entity ID Scoped Names | Accepted | 2024-12 |
-| [0004](0004-atomic-write-pattern.md) | Atomic Write Pattern | Accepted | 2024-12 |
-| [0005](0005-two-pass-parsing.md) | Two-Pass Parsing Architecture | Accepted | 2024-12 |
-| [0006](0006-python-parser-subprocess.md) | Python Parser via Subprocess | Accepted | 2024-12 |
-| [0007](0007-federation-central-hub.md) | Federation with Central Hub | Accepted | 2024-12 |
-| [0008](0008-content-hash-incremental.md) | Content Hash for Incremental Analysis | Accepted | 2024-12 |
-| [0009](0009-windows-support-deferred.md) | Windows Support Deferred | Accepted | 2024-12 |
-| [0010](0010-recursive-cte-depth-limit.md) | Recursive CTE Depth Limit | Accepted | 2024-12 |
-| [0011](0011-development-workflow.md) | Development Workflow | Accepted | 2024-12 |
-| [0012](0012-claude-assisted-slash-commands.md) | Claude-Assisted Slash Commands | Accepted | 2024-12 |
-| [0013](0013-fixture-packages-per-language.md) | Fixture Packages Per Language | Accepted | 2024-12 |
-| [0014](0014-worktree-claude-workflow.md) | Git Worktree + Claude CLI Workflow | Accepted | 2024-12 |
-| [0015](0015-conceptual-foundation.md) | Conceptual Foundation - Effect Handler Pattern | Accepted | 2024-12 |
-| [0016](0016-workspace-module.md) | Workspace Module Architecture | Accepted | 2025-01 |
-| [0017](0017-validation-hub-cache.md) | Validation Hub Cache | Accepted | 2025-01 |
-| [0018](0018-unified-diagnostics-model.md) | Unified Diagnostics Model | Accepted | 2025-01 |
-| [0019](0019-coverage-validator.md) | Coverage Validator Integration | Accepted | 2025-01 |
-| [0020](0020-calls-edge-extraction.md) | CALLS Edge Extraction for Function Call Tracking | Accepted | 2025-01 |
-| [0021](0021-code-understanding-pipeline-doc.md) | Code Understanding Pipeline Documentation | Accepted | 2025-01 |
-| [0022](0022-answer-quality-evaluation.md) | Answer Quality Evaluation Framework | Accepted | 2025-01 |
-| [0023](0023-developer-maintained-effects.md) | Developer Maintained Effects | Accepted | 2025-01 |
+| [0001](0001-replace-neo4j-with-duckdb.md) | Replace Neo4j with DuckDB | Accepted | 2025-12 |
+| [0002](0002-per-package-partitioning.md) | Per-Package Partitioning | Accepted | 2025-12 |
+| [0003](0003-entity-id-scoped-names.md) | Entity ID Scoped Names | Accepted | 2025-12 |
+| [0004](0004-atomic-write-pattern.md) | Atomic Write Pattern | Accepted | 2025-12 |
+| [0005](0005-two-pass-parsing.md) | Two-Pass Parsing Architecture | Accepted | 2025-12 |
+| [0006](0006-python-parser-subprocess.md) | Python Parser via Subprocess | Accepted | 2025-12 |
+| [0007](0007-federation-central-hub.md) | Federation with Central Hub | Accepted | 2025-12 |
+| [0008](0008-content-hash-incremental.md) | Content Hash for Incremental Analysis | Accepted | 2025-12 |
+| [0009](0009-windows-support-deferred.md) | Windows Support Deferred | Accepted | 2025-12 |
+| [0010](0010-recursive-cte-depth-limit.md) | Recursive CTE Depth Limit | Accepted | 2025-12 |
+| [0011](0011-development-workflow.md) | Development Workflow | Accepted | 2025-12 |
+| [0012](0012-claude-assisted-slash-commands.md) | Claude-Assisted Slash Commands | Accepted | 2025-12 |
+| [0013](0013-fixture-packages-per-language.md) | Fixture Packages Per Language | Accepted | 2025-12 |
+| [0014](0014-worktree-claude-workflow.md) | Git Worktree + Claude CLI Workflow | Accepted | 2025-12 |
+| [0015](0015-conceptual-foundation.md) | Conceptual Foundation - Effect Handler Pattern | Accepted | 2025-12 |
+| [0016](0016-workspace-module.md) | Workspace Module Architecture | Accepted | 2026-01 |
+| [0017](0017-validation-hub-cache.md) | Validation Hub Cache | Accepted | 2026-01 |
+| [0018](0018-unified-diagnostics-model.md) | Unified Diagnostics Model | Accepted | 2026-01 |
+| [0019](0019-coverage-validator.md) | Coverage Validator Integration | Accepted | 2026-01 |
+| [0020](0020-calls-edge-extraction.md) | CALLS Edge Extraction for Function Call Tracking | Accepted | 2026-01 |
+| [0021](0021-code-understanding-pipeline-doc.md) | Code Understanding Pipeline Documentation | Accepted | 2026-01 |
+| [0022](0022-answer-quality-evaluation.md) | Answer Quality Evaluation Framework | Accepted | 2026-01 |
+| [0023](0023-developer-maintained-effects.md) | Developer Maintained Effects | Accepted | 2026-01 |
 | [0024](0024-hub-single-writer-ipc.md) | Hub Single Writer Architecture with IPC | Accepted | 2026-01 |
 | [0025](0025-unified-start-issue-command.md) | Unified Start-Issue Command | Accepted | 2026-01 |
 | [0026](0026-federated-documentation-generation.md) | Federated Documentation Generation | Accepted | 2026-01 |

--- a/docs/spec/ramblings.md
+++ b/docs/spec/ramblings.md
@@ -4,6 +4,18 @@ This is file is used to create and edit prompts snippets for pasting into llm ch
 
 Its in no way presenting the prompt used, they can be ramblings to set the context in my mind and ask claude to organise them into usefull prompts.
 
+# notes
+
+lets keep an eye on devac-cli/docs/package-effects.md grouping got lost in pr 122 2026-01-10 versus 2026-01-06
+
+also observability as effect type is no longer mentioned
+
+test with no implementation needs addressing
+
+we need to standardize the commands and their usage
+
+architecture validation .md and .c4 are not the same it seems, can you have a good look at devac-core docs/c4/vali
+
 # recap improve-pipline
 
 Can you turn below ramblings into a prompt to make sure we understand each other get in sync so we end up with a good solid starting point to create a plan.


### PR DESCRIPTION
## Summary
- Fixed ADR README dates (year correction: 2024→2025, 2025→2026)
- Added notes section to ramblings.md for tracking improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)