### PR TITLE
fix(plugin): run gh issue view from worktree directory

### DIFF
--- a/plugins/devac/commands/start-issue.md
+++ b/plugins/devac/commands/start-issue.md
@@ -61,9 +61,13 @@ git rev-parse --show-toplevel 2>/dev/null
 
 **Step 3: Fetch issue with comments and enter plan mode**
 
+Run the `gh` command from within the worktree directory (where git context is available):
+
 ```bash
-gh issue view <issue-number> --json number,title,body,comments,labels
+cd <worktree-path> && gh issue view <issue-number> --json number,title,body,comments,labels
 ```
+
+The worktree path is printed in Step 1 output (e.g., `~/ws/vivief-42-add-feature/`).
 
 Create a plan file at `.claude/plans/<generated-name>.md` with:
 


### PR DESCRIPTION
## Summary

- Fixed bug where `gh issue view` fails when `/devac:start-issue` runs from workspace root
- Updated Step 3 instructions to `cd` into the worktree directory before running `gh`

## Problem

When running `/devac:start-issue` from `~/ws/` (workspace root, not a git repo), the `gh issue view` command fails with:

```
Could not resolve to a Repository with the name 'grop/vivief'
```

The `gh` CLI needs to run from within a git repository to infer the `owner/repo` from the git remote.

## Test plan

- [ ] From `~/ws/`, run `/devac:start-issue ghvivief-<number>`
- [ ] Verify `gh issue view` succeeds without the "Could not resolve" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)