### PR TITLE
fix(mcp): Fix broken MCP tools - query_sql and get_workspace_status

### DIFF
--- a/.changeset/fix-mcp-tools-broken.md
+++ b/.changeset/fix-mcp-tools-broken.md
@@ -1,0 +1,23 @@
+---
+"@pietgk/devac-core": patch
+"@pietgk/devac-mcp": patch
+---
+
+fix(mcp): Fix broken MCP tools - query_sql and get_workspace_status
+
+**Root causes and fixes:**
+
+1. **Workspace status silent failures**: Hub connection errors were silently swallowed by an empty catch block. Now surfaces errors via new `hubError` field in `WorkspaceStatus`.
+
+2. **Package path resolution**: `getPackagePaths()` was returning repository paths instead of actual package paths. Now reads `.devac/manifest.json` to extract real package paths.
+
+3. **Overly-restrictive path validation**: `checkForRootSeeds()` filtered out any path containing `.git`, breaking single-package repos where seeds live at repo root. Removed this validation - the unified query system now trusts all provided paths (caller is responsible for valid paths from manifest).
+
+4. **Misleading schema documentation**: `get_schema` incorrectly implied hub tables (repo_registry, validation_errors, unified_diagnostics) were SQL-queryable. Updated descriptions to clarify these require dedicated MCP tools.
+
+**Impact:**
+- `query_sql` now works correctly for single-package repos
+- `get_workspace_status` now reports hub errors instead of showing "unregistered"
+- `get_schema` output is now accurate about what's SQL-queryable
+
+Closes #148

--- a/docs/adr/0030-unified-query-system.md
+++ b/docs/adr/0030-unified-query-system.md
@@ -78,7 +78,7 @@ interface QueryResult<T = Record<string, unknown>> {
   timeMs: number;
   viewsCreated: string[];      // e.g., ["nodes", "edges", "effects"]
   packagesQueried: string[];   // Actually queried (after filtering)
-  warnings: string[];          // e.g., root-level seed warnings
+  warnings: string[];          // e.g., "No packages provided to query"
 }
 
 async function query<T>(pool: DuckDBPool, config: QueryConfig): Promise<QueryResult<T>>;
@@ -90,9 +90,10 @@ async function query<T>(pool: DuckDBPool, config: QueryConfig): Promise<QueryRes
    - Single package: `CREATE VIEW nodes AS SELECT * FROM read_parquet('path')`
    - Multiple packages: `CREATE VIEW nodes AS SELECT * FROM read_parquet(['path1', 'path2'])`
 
-2. **Root-Level Seed Detection**:
-   - Warns if seeds exist at repo root (should only be at package level)
-   - Skips invalid paths instead of throwing
+2. **Path Trust Model**:
+   - All provided package paths are trusted (caller responsible for valid paths)
+   - Supports single-package repos where seeds exist at repo root
+   - Skips paths without parquet files instead of throwing
 
 3. **Automatic View Management**:
    - Creates `nodes`, `edges`, `external_refs`, `effects` views as needed

--- a/packages/devac-core/src/workspace/status.ts
+++ b/packages/devac-core/src/workspace/status.ts
@@ -80,6 +80,9 @@ export interface WorkspaceStatus {
   /** Whether the hub is initialized */
   hubInitialized: boolean;
 
+  /** Error message if hub connection failed */
+  hubError?: string;
+
   /** Status for each repository */
   repos: RepoStatus[];
 
@@ -172,6 +175,8 @@ export async function getWorkspaceStatus(options: StatusOptions = {}): Promise<W
 
   // Get registered repos from hub (if available)
   const registeredRepoIds = new Set<string>();
+  let hubError: string | undefined;
+
   if (hubInitialized) {
     try {
       const hub = new CentralHub({ hubDir });
@@ -181,8 +186,9 @@ export async function getWorkspaceStatus(options: StatusOptions = {}): Promise<W
         registeredRepoIds.add(repo.repoId);
       }
       await hub.close();
-    } catch {
-      // Hub exists but couldn't connect
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      hubError = `Hub connection error: ${message}`;
     }
   }
 
@@ -228,6 +234,7 @@ export async function getWorkspaceStatus(options: StatusOptions = {}): Promise<W
     isWorkspace,
     hubPath: hubInitialized ? hubPath : undefined,
     hubInitialized,
+    hubError,
     repos,
     summary,
   };

--- a/packages/devac-mcp/src/server.ts
+++ b/packages/devac-mcp/src/server.ts
@@ -419,15 +419,18 @@ export class DevacMCPServer {
       },
       hubTables: {
         repo_registry: {
-          description: "Registered repositories and their metadata",
+          description:
+            "Registered repositories and their metadata. NOT SQL-queryable - use list_repos tool instead.",
           columns: ["repo_id", "local_path", "packages", "status", "last_synced"],
         },
         validation_errors: {
-          description: "Type errors, lint issues from validators",
+          description:
+            "Type errors, lint issues from validators. NOT SQL-queryable - use get_validation_errors tool instead.",
           columns: ["error_id", "repo_id", "source", "severity", "file_path", "line", "message"],
         },
         unified_diagnostics: {
-          description: "All diagnostics unified (validation + CI + GitHub issues)",
+          description:
+            "All diagnostics unified (validation + CI + GitHub issues). NOT SQL-queryable - use get_all_diagnostics tool instead.",
           columns: [
             "diagnostic_id",
             "repo_id",
@@ -443,7 +446,8 @@ export class DevacMCPServer {
       tips: [
         "Use COUNT(*)::INT to avoid BigInt serialization errors",
         "Prefer dedicated MCP tools (get_diagnostics_counts, etc.) over raw SQL when available",
-        "In hub mode, seed tables query across all registered repositories",
+        "In hub mode, seed tables (nodes, edges, etc.) query across all registered repositories",
+        "Hub tables (repo_registry, validation_errors, unified_diagnostics) are NOT SQL-queryable - use their dedicated MCP tools",
       ],
     };
 


### PR DESCRIPTION
## Summary

- **Fix workspace status silent failures**: Hub connection errors were silently swallowed. Now surfaces errors via new `hubError` field
- **Fix package path resolution**: `getPackagePaths()` now reads manifests to get actual package paths instead of returning repo paths
- **Remove overly-restrictive path validation**: `checkForRootSeeds()` broke single-package repos. Unified query now trusts all provided paths
- **Fix misleading schema docs**: `get_schema` now correctly states hub tables require dedicated MCP tools (not SQL-queryable)

## Test plan

- [x] All existing tests pass (315 tests)
- [x] Updated unified-query tests to reflect new behavior (repo roots with seeds are now valid)
- [x] Typecheck passes
- [x] Lint passes

Closes #148

🤖 Generated with [Claude Code](https://claude.ai/code)