### PR TITLE
feat(rules): add grouping and significance rules for C4 generation

### DIFF
--- a/.changeset/improve-domain-effects-c4.md
+++ b/.changeset/improve-domain-effects-c4.md
@@ -1,0 +1,16 @@
+---
+"@pietgk/devac-core": minor
+"@pietgk/devac-cli": minor
+---
+
+Add grouping and significance rules for improved C4 architecture generation
+
+- Add `GroupingRule` interface and built-in layer rules (Analysis, Storage, Federation, API, Rules, Views)
+- Add `SignificanceRule` interface for classifying architectural importance (critical, important, minor, hidden)
+- Integrate rule-based grouping and significance filtering into C4 generator
+- Enhance `devac architecture score` command with:
+  - Gap metrics with target comparisons (Container F1, Signal-to-Noise, Relationship F1, External F1)
+  - `--with-rules` flag for rule-based analysis
+  - `--show-targets` flag for displaying target thresholds
+  - Improvement suggestions based on gap analysis
+- Add C4 quality rules documentation for validate-architecture skill

--- a/docs/adr/0031-architecture-quality-improvement-loop.md
+++ b/docs/adr/0031-architecture-quality-improvement-loop.md
@@ -105,15 +105,19 @@ For human-validated architecture:
 ### Implementation Components
 
 ```
-packages/devac-core/src/views/gap-metrics.ts       # Metric calculation
+packages/devac-core/src/rules/grouping-rules.ts    # Container grouping rules (6 layers)
+packages/devac-core/src/rules/significance-rules.ts # Significance filtering rules (4 levels)
+packages/devac-core/src/views/gap-metrics.ts       # Metric calculation with targets
+packages/devac-core/src/views/c4-generator.ts      # Rule-based C4 generation
 packages/devac-core/src/views/likec4-json-parser.ts # Parse LikeC4 for comparison
-packages/devac-cli/src/commands/architecture.ts    # CLI commands
+packages/devac-cli/src/commands/architecture.ts    # CLI commands (score, status, diff)
 
 docs/plans/gap-metrics.md                          # Metric definitions
 docs/plans/rule-improvement-workflow.md            # Rule development process
 docs/plans/multi-level-coordination.md             # Level coordination
 
 plugins/devac/skills/validate-architecture/        # Human validation skill
+plugins/devac/skills/validate-architecture/knowledge/c4-quality-rules.md # M1-M4 quality rules
 ```
 
 ### CLI Commands
@@ -122,11 +126,16 @@ plugins/devac/skills/validate-architecture/        # Human validation skill
 # Generate architecture documentation
 devac c4 --package <path>
 
-# Score architecture quality (future)
-devac architecture score
+# Score architecture quality with gap metrics
+devac architecture score -p <path>
+devac architecture score -p <path> --with-rules  # Include rule analysis
+devac architecture score -p <path> --with-rules -v  # Verbose with matched rules
 
 # Check architecture staleness
-devac architecture status
+devac architecture status -p <path>
+
+# Show structural differences
+devac architecture diff -p <path>
 
 # Validate architecture constraints
 devac validate --architecture

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,8 @@ An Architecture Decision Record captures an important architectural decision mad
 | [0030](0030-unified-query-system.md) | Unified Query System Architecture | Accepted | 2026-01 |
 | [0031](0031-architecture-quality-improvement-loop.md) | Architecture Documentation Quality Improvement Loop | Accepted | 2026-01 |
 | [0032](0032-hub-location-validation.md) | Hub Location Validation | Accepted | 2026-01 |
+| [0033](0033-calls-edge-resolution.md) | CALLS Edge Resolution for Call Graph Queries | Accepted | 2026-01 |
+| [0034](0034-extends-edge-resolution.md) | EXTENDS Edge Resolution for Inheritance Queries | Accepted | 2026-01 |
 
 ## Creating a New ADR
 

--- a/packages/devac-core/src/index.ts
+++ b/packages/devac-core/src/index.ts
@@ -340,6 +340,35 @@ export {
   observabilityRules,
   getRulesByDomain,
   getRulesByProvider,
+  // Grouping rules (v3.0 - container assignment)
+  GroupingEngine,
+  createGroupingEngine,
+  defineGroupingRule,
+  builtinGroupingRules,
+  analysisLayerRules,
+  storageLayerRules,
+  federationLayerRules,
+  apiLayerRules,
+  rulesLayerRules,
+  viewsLayerRules,
+  getGroupingRulesByContainer,
+  getGroupingRulesByLayer,
+  getAvailableContainers,
+  getAvailableTags,
+  // Significance rules (v3.0 - architectural importance)
+  SignificanceEngine,
+  createSignificanceEngine,
+  defineSignificanceRule,
+  buildSignificanceContext,
+  builtinSignificanceRules,
+  criticalSignificanceRules,
+  importantSignificanceRules,
+  minorSignificanceRules,
+  hiddenSignificanceRules,
+  getSignificanceRulesByLevel,
+  getSignificanceRulesByDomain,
+  getSignificanceLevelValue,
+  compareSignificanceLevels,
 } from "./rules/index.js";
 export type {
   Rule,
@@ -348,6 +377,22 @@ export type {
   DomainEffect,
   RuleEngineResult,
   RuleEngineConfig,
+  // Grouping rules types
+  GroupingRule,
+  GroupingMatch,
+  GroupingEmit,
+  GroupingResult,
+  GroupingEngineConfig,
+  GroupingEngineStats,
+  // Significance rules types
+  SignificanceRule,
+  SignificanceMatch,
+  SignificanceEmit,
+  SignificanceResult,
+  SignificanceLevel,
+  SignificanceContext,
+  SignificanceEngineConfig,
+  SignificanceEngineStats,
 } from "./rules/index.js";
 
 // Views (v3.0 foundation - Vision→View pipeline)
@@ -357,6 +402,9 @@ export {
   exportContextToPlantUML,
   exportContainersToPlantUML,
   discoverDomainBoundaries,
+  // Rule-based filtering and grouping (v3.0)
+  applySignificanceFiltering,
+  applyGroupingRules,
   // Effect enrichment (for readable C4 diagrams)
   enrichDomainEffects,
   extractFallbackName,
@@ -378,6 +426,8 @@ export {
   calculateExternalF1,
   analyzeGap,
   formatGapAnalysis,
+  // Gap target constants
+  DEFAULT_GAP_TARGETS,
 } from "./views/index.js";
 export type {
   C4ExternalSystem,
@@ -399,6 +449,9 @@ export type {
   F1Score,
   GapMetric,
   GapAnalysis,
+  GapTargets,
+  GapAnalysisOptions,
+  RuleAnalysisResult,
 } from "./views/index.js";
 
 // Enriched Effects Types (for C4 enrichment)

--- a/packages/devac-core/src/rules/grouping-rules.ts
+++ b/packages/devac-core/src/rules/grouping-rules.ts
@@ -1,0 +1,734 @@
+/**
+ * Grouping Rules - Container/Layer Assignment
+ *
+ * Rules for grouping components into logical containers and layers
+ * for C4 diagram generation. Unlike domain rules that classify effects
+ * by their behavior, grouping rules classify by architectural role.
+ *
+ * Part of DevAC v3.0 Foundation.
+ */
+
+import type { EnrichedDomainEffect } from "../types/enriched-effects.js";
+import type { DomainEffect } from "./rule-engine.js";
+
+/**
+ * Match criteria for a grouping rule
+ */
+export interface GroupingMatch {
+  /** File path pattern (string for includes, RegExp for pattern) */
+  filePath?: string | RegExp;
+  /** Entity kind to match (function, class, method, etc.) */
+  entityKind?: string | string[];
+  /** Entity name pattern */
+  entityName?: string | RegExp;
+  /** Match effects in specific domain(s) */
+  domain?: string | string[];
+  /** Match effects with specific action(s) */
+  action?: string | string[];
+  /** Custom predicate for complex matching */
+  predicate?: (effect: DomainEffect | EnrichedDomainEffect) => boolean;
+}
+
+/**
+ * What the grouping rule emits when matched
+ */
+export interface GroupingEmit {
+  /** Container/layer name (e.g., "Analysis Layer") */
+  container: string;
+  /** Optional layer classification for hierarchical grouping */
+  layer?: "presentation" | "application" | "domain" | "infrastructure";
+  /** Additional tags for filtering and visualization */
+  tags?: string[];
+}
+
+/**
+ * A rule that assigns effects to containers/layers
+ */
+export interface GroupingRule {
+  /** Unique rule identifier */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Description of what this rule matches */
+  description?: string;
+  /** Match criteria */
+  match: GroupingMatch;
+  /** Container/layer assignment */
+  emit: GroupingEmit;
+  /** Priority (higher = evaluated first) */
+  priority?: number;
+  /** Whether this rule is enabled */
+  enabled?: boolean;
+}
+
+/**
+ * Result of applying grouping rules to an effect
+ */
+export interface GroupingResult {
+  /** Original effect */
+  effect: DomainEffect | EnrichedDomainEffect;
+  /** Assigned container */
+  container: string;
+  /** Assigned layer (if any) */
+  layer?: string;
+  /** Rule that matched (null if default) */
+  ruleId: string | null;
+  /** Tags from the matched rule */
+  tags: string[];
+}
+
+/**
+ * Type guard to check if a DomainEffect is enriched
+ */
+function isEnrichedEffect(
+  effect: DomainEffect | EnrichedDomainEffect
+): effect is EnrichedDomainEffect {
+  return "sourceName" in effect && "relativeFilePath" in effect;
+}
+
+/**
+ * Get file path from effect (relative if enriched, absolute otherwise)
+ */
+function getEffectPath(effect: DomainEffect | EnrichedDomainEffect): string {
+  return isEnrichedEffect(effect) ? effect.relativeFilePath : effect.filePath;
+}
+
+/**
+ * Get entity name from effect (readable name if enriched)
+ */
+function getEffectName(effect: DomainEffect | EnrichedDomainEffect): string {
+  return isEnrichedEffect(effect) ? effect.sourceName : effect.sourceEntityId;
+}
+
+/**
+ * Get entity kind from effect (if enriched)
+ */
+function getEffectKind(effect: DomainEffect | EnrichedDomainEffect): string | undefined {
+  return isEnrichedEffect(effect) ? effect.sourceKind : undefined;
+}
+
+/**
+ * Check if a string matches a pattern (string or RegExp)
+ */
+function matchesPattern(value: string | null | undefined, pattern: string | RegExp): boolean {
+  if (value == null) return false;
+  if (typeof pattern === "string") {
+    return value.includes(pattern);
+  }
+  return pattern.test(value);
+}
+
+/**
+ * Check if a value is in an array (or matches if not array)
+ */
+function matchesArrayOrValue<T>(value: T, arrayOrValue: T | T[]): boolean {
+  if (Array.isArray(arrayOrValue)) {
+    return arrayOrValue.includes(value);
+  }
+  return value === arrayOrValue;
+}
+
+/**
+ * Check if an effect matches a grouping rule's criteria
+ */
+function effectMatchesGroupingRule(
+  effect: DomainEffect | EnrichedDomainEffect,
+  match: GroupingMatch
+): boolean {
+  // Check file path
+  if (match.filePath) {
+    const path = getEffectPath(effect);
+    if (!matchesPattern(path, match.filePath)) {
+      return false;
+    }
+  }
+
+  // Check entity kind (only for enriched effects)
+  if (match.entityKind) {
+    const kind = getEffectKind(effect);
+    if (kind === undefined) {
+      return false;
+    }
+    if (!matchesArrayOrValue(kind, match.entityKind)) {
+      return false;
+    }
+  }
+
+  // Check entity name
+  if (match.entityName) {
+    const name = getEffectName(effect);
+    if (!matchesPattern(name, match.entityName)) {
+      return false;
+    }
+  }
+
+  // Check domain
+  if (match.domain) {
+    if (!matchesArrayOrValue(effect.domain, match.domain)) {
+      return false;
+    }
+  }
+
+  // Check action
+  if (match.action) {
+    if (!matchesArrayOrValue(effect.action, match.action)) {
+      return false;
+    }
+  }
+
+  // Run custom predicate if provided
+  if (match.predicate) {
+    if (!match.predicate(effect)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Utility to create a grouping rule with defaults
+ */
+export function defineGroupingRule(
+  rule: Omit<GroupingRule, "enabled"> & { enabled?: boolean }
+): GroupingRule {
+  return {
+    ...rule,
+    enabled: rule.enabled ?? true,
+    priority: rule.priority ?? 0,
+  };
+}
+
+// =============================================================================
+// Analysis Layer Rules
+// =============================================================================
+
+/**
+ * Rules for the Analysis Layer - parsers, analyzers, semantic resolution
+ */
+export const analysisLayerRules: GroupingRule[] = [
+  defineGroupingRule({
+    id: "grouping-parsers",
+    name: "Parsers",
+    description: "Tree-sitter parsers and AST processing",
+    match: {
+      filePath: /parsers?[\/\-]/i,
+    },
+    emit: {
+      container: "Analysis Layer",
+      layer: "domain",
+      tags: ["parser", "ast"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-analyzers",
+    name: "Analyzers",
+    description: "Code analysis and extraction logic",
+    match: {
+      filePath: /analyz(er|e|ing)/i,
+    },
+    emit: {
+      container: "Analysis Layer",
+      layer: "domain",
+      tags: ["analyzer"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-semantic-resolver",
+    name: "Semantic Resolver",
+    description: "Semantic analysis and symbol resolution",
+    match: {
+      filePath: /semantic|resolver|symbols?/i,
+    },
+    emit: {
+      container: "Analysis Layer",
+      layer: "domain",
+      tags: ["semantic"],
+    },
+    priority: 15,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-extractors",
+    name: "Extractors",
+    description: "Data extraction from parsed code",
+    match: {
+      filePath: /extract(or|ion)?/i,
+    },
+    emit: {
+      container: "Analysis Layer",
+      layer: "domain",
+      tags: ["extractor"],
+    },
+    priority: 15,
+  }),
+];
+
+// =============================================================================
+// Storage Layer Rules
+// =============================================================================
+
+/**
+ * Rules for the Storage Layer - DuckDB, Parquet, seed management
+ */
+export const storageLayerRules: GroupingRule[] = [
+  defineGroupingRule({
+    id: "grouping-duckdb",
+    name: "DuckDB Operations",
+    description: "DuckDB database operations and queries",
+    match: {
+      filePath: /duckdb|duck-?db/i,
+    },
+    emit: {
+      container: "Storage Layer",
+      layer: "infrastructure",
+      tags: ["database", "duckdb"],
+    },
+    priority: 25,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-parquet",
+    name: "Parquet Storage",
+    description: "Parquet file handling",
+    match: {
+      filePath: /parquet/i,
+    },
+    emit: {
+      container: "Storage Layer",
+      layer: "infrastructure",
+      tags: ["storage", "parquet"],
+    },
+    priority: 25,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-seeds",
+    name: "Seed Management",
+    description: "Seed file generation and management",
+    match: {
+      filePath: /seeds?[\/\-]|seed-?writer|seed-?reader/i,
+    },
+    emit: {
+      container: "Storage Layer",
+      layer: "infrastructure",
+      tags: ["seed"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-cache",
+    name: "Cache Layer",
+    description: "Caching mechanisms",
+    match: {
+      filePath: /cache/i,
+    },
+    emit: {
+      container: "Storage Layer",
+      layer: "infrastructure",
+      tags: ["cache"],
+    },
+    priority: 15,
+  }),
+];
+
+// =============================================================================
+// Federation Layer Rules
+// =============================================================================
+
+/**
+ * Rules for the Federation Layer - cross-repo, hub, registry
+ */
+export const federationLayerRules: GroupingRule[] = [
+  defineGroupingRule({
+    id: "grouping-hub",
+    name: "Central Hub",
+    description: "Central hub for cross-repo federation",
+    match: {
+      filePath: /hub|central/i,
+    },
+    emit: {
+      container: "Federation Layer",
+      layer: "application",
+      tags: ["hub", "federation"],
+    },
+    priority: 25,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-registry",
+    name: "Registry",
+    description: "Package/repo registry management",
+    match: {
+      filePath: /registry|manifest/i,
+    },
+    emit: {
+      container: "Federation Layer",
+      layer: "application",
+      tags: ["registry"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-federation-client",
+    name: "Federation Client",
+    description: "Client for cross-repo queries",
+    match: {
+      filePath: /federat(e|ion)|cross-?repo/i,
+    },
+    emit: {
+      container: "Federation Layer",
+      layer: "application",
+      tags: ["federation", "client"],
+    },
+    priority: 15,
+  }),
+];
+
+// =============================================================================
+// API Layer Rules
+// =============================================================================
+
+/**
+ * Rules for the API Layer - MCP tools, CLI commands
+ */
+export const apiLayerRules: GroupingRule[] = [
+  defineGroupingRule({
+    id: "grouping-mcp-tools",
+    name: "MCP Tools",
+    description: "MCP server tools for AI assistants",
+    match: {
+      filePath: /mcp|tools?[\/\-]/i,
+    },
+    emit: {
+      container: "API Layer",
+      layer: "presentation",
+      tags: ["mcp", "api"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-cli-commands",
+    name: "CLI Commands",
+    description: "Command-line interface commands",
+    match: {
+      filePath: /commands?[\/\-]/i,
+    },
+    emit: {
+      container: "API Layer",
+      layer: "presentation",
+      tags: ["cli", "command"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-handlers",
+    name: "Request Handlers",
+    description: "Request/event handlers",
+    match: {
+      filePath: /handlers?[\/\-]/i,
+    },
+    emit: {
+      container: "API Layer",
+      layer: "presentation",
+      tags: ["handler"],
+    },
+    priority: 15,
+  }),
+];
+
+// =============================================================================
+// Rules Layer Rules
+// =============================================================================
+
+/**
+ * Rules for the Rules Layer - rule engine, builtin rules
+ */
+export const rulesLayerRules: GroupingRule[] = [
+  defineGroupingRule({
+    id: "grouping-rule-engine",
+    name: "Rule Engine",
+    description: "Core rule engine for effect classification",
+    match: {
+      filePath: /rule-?engine/i,
+    },
+    emit: {
+      container: "Rules Layer",
+      layer: "domain",
+      tags: ["rules", "engine"],
+    },
+    priority: 25,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-builtin-rules",
+    name: "Builtin Rules",
+    description: "Predefined domain effect rules",
+    match: {
+      filePath: /builtin-?rules|domain-?rules/i,
+    },
+    emit: {
+      container: "Rules Layer",
+      layer: "domain",
+      tags: ["rules", "builtin"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-rules-generic",
+    name: "Rules",
+    description: "Generic rules directory",
+    match: {
+      filePath: /\/rules\//i,
+    },
+    emit: {
+      container: "Rules Layer",
+      layer: "domain",
+      tags: ["rules"],
+    },
+    priority: 10,
+  }),
+];
+
+// =============================================================================
+// Views Layer Rules
+// =============================================================================
+
+/**
+ * Rules for the Views Layer - C4 generation, diagram output
+ */
+export const viewsLayerRules: GroupingRule[] = [
+  defineGroupingRule({
+    id: "grouping-c4-generator",
+    name: "C4 Generator",
+    description: "C4 diagram generation",
+    match: {
+      filePath: /c4|diagram/i,
+    },
+    emit: {
+      container: "Views Layer",
+      layer: "presentation",
+      tags: ["c4", "diagram"],
+    },
+    priority: 20,
+  }),
+
+  defineGroupingRule({
+    id: "grouping-views-generic",
+    name: "Views",
+    description: "Generic views directory",
+    match: {
+      filePath: /\/views\//i,
+    },
+    emit: {
+      container: "Views Layer",
+      layer: "presentation",
+      tags: ["views"],
+    },
+    priority: 10,
+  }),
+];
+
+// =============================================================================
+// Combined Grouping Rules
+// =============================================================================
+
+/**
+ * All builtin grouping rules combined
+ */
+export const builtinGroupingRules: GroupingRule[] = [
+  ...analysisLayerRules,
+  ...storageLayerRules,
+  ...federationLayerRules,
+  ...apiLayerRules,
+  ...rulesLayerRules,
+  ...viewsLayerRules,
+];
+
+// =============================================================================
+// Grouping Engine
+// =============================================================================
+
+/**
+ * Configuration for the grouping engine
+ */
+export interface GroupingEngineConfig {
+  /** Rules to apply */
+  rules: GroupingRule[];
+  /** Default container for unmatched effects */
+  defaultContainer?: string;
+  /** Default layer for unmatched effects */
+  defaultLayer?: "presentation" | "application" | "domain" | "infrastructure";
+}
+
+/**
+ * Statistics from grouping engine run
+ */
+export interface GroupingEngineStats {
+  /** Total effects processed */
+  totalEffects: number;
+  /** Effects matched by rules */
+  matchedCount: number;
+  /** Effects using default container */
+  defaultCount: number;
+  /** Rule match counts */
+  ruleStats: Map<string, number>;
+  /** Container distribution */
+  containerStats: Map<string, number>;
+}
+
+/**
+ * Engine for applying grouping rules to effects
+ */
+export class GroupingEngine {
+  private rules: GroupingRule[];
+  private defaultContainer: string;
+  private defaultLayer?: string;
+
+  constructor(config: GroupingEngineConfig) {
+    // Sort rules by priority (higher first)
+    this.rules = [...config.rules]
+      .filter((r) => r.enabled !== false)
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    this.defaultContainer = config.defaultContainer ?? "Other";
+    this.defaultLayer = config.defaultLayer;
+  }
+
+  /**
+   * Apply grouping rules to a single effect
+   */
+  applyToEffect(effect: DomainEffect | EnrichedDomainEffect): GroupingResult {
+    for (const rule of this.rules) {
+      if (effectMatchesGroupingRule(effect, rule.match)) {
+        return {
+          effect,
+          container: rule.emit.container,
+          layer: rule.emit.layer,
+          ruleId: rule.id,
+          tags: rule.emit.tags ?? [],
+        };
+      }
+    }
+
+    // No rule matched, use default
+    return {
+      effect,
+      container: this.defaultContainer,
+      layer: this.defaultLayer,
+      ruleId: null,
+      tags: [],
+    };
+  }
+
+  /**
+   * Apply grouping rules to multiple effects
+   */
+  applyToEffects(effects: (DomainEffect | EnrichedDomainEffect)[]): {
+    results: GroupingResult[];
+    stats: GroupingEngineStats;
+  } {
+    const results: GroupingResult[] = [];
+    const ruleStats = new Map<string, number>();
+    const containerStats = new Map<string, number>();
+    let matchedCount = 0;
+    let defaultCount = 0;
+
+    // Initialize rule stats
+    for (const rule of this.rules) {
+      ruleStats.set(rule.id, 0);
+    }
+
+    for (const effect of effects) {
+      const result = this.applyToEffect(effect);
+      results.push(result);
+
+      // Update stats
+      if (result.ruleId) {
+        matchedCount++;
+        ruleStats.set(result.ruleId, (ruleStats.get(result.ruleId) ?? 0) + 1);
+      } else {
+        defaultCount++;
+      }
+
+      containerStats.set(result.container, (containerStats.get(result.container) ?? 0) + 1);
+    }
+
+    return {
+      results,
+      stats: {
+        totalEffects: effects.length,
+        matchedCount,
+        defaultCount,
+        ruleStats,
+        containerStats,
+      },
+    };
+  }
+
+  /**
+   * Get all registered rules
+   */
+  getRules(): readonly GroupingRule[] {
+    return this.rules;
+  }
+}
+
+/**
+ * Create a grouping engine with the given configuration
+ */
+export function createGroupingEngine(config: GroupingEngineConfig): GroupingEngine {
+  return new GroupingEngine(config);
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Get grouping rules by container
+ */
+export function getGroupingRulesByContainer(container: string): GroupingRule[] {
+  return builtinGroupingRules.filter((rule) => rule.emit.container === container);
+}
+
+/**
+ * Get grouping rules by layer
+ */
+export function getGroupingRulesByLayer(
+  layer: "presentation" | "application" | "domain" | "infrastructure"
+): GroupingRule[] {
+  return builtinGroupingRules.filter((rule) => rule.emit.layer === layer);
+}
+
+/**
+ * Get all unique containers from rules
+ */
+export function getAvailableContainers(): string[] {
+  const containers = new Set<string>();
+  for (const rule of builtinGroupingRules) {
+    containers.add(rule.emit.container);
+  }
+  return Array.from(containers).sort();
+}
+
+/**
+ * Get all unique tags from rules
+ */
+export function getAvailableTags(): string[] {
+  const tags = new Set<string>();
+  for (const rule of builtinGroupingRules) {
+    for (const tag of rule.emit.tags ?? []) {
+      tags.add(tag);
+    }
+  }
+  return Array.from(tags).sort();
+}

--- a/packages/devac-core/src/rules/index.ts
+++ b/packages/devac-core/src/rules/index.ts
@@ -32,3 +32,52 @@ export {
   getRulesByDomain,
   getRulesByProvider,
 } from "./builtin-rules.js";
+
+// Grouping rules
+export {
+  GroupingEngine,
+  createGroupingEngine,
+  defineGroupingRule,
+  builtinGroupingRules,
+  analysisLayerRules,
+  storageLayerRules,
+  federationLayerRules,
+  apiLayerRules,
+  rulesLayerRules,
+  viewsLayerRules,
+  getGroupingRulesByContainer,
+  getGroupingRulesByLayer,
+  getAvailableContainers,
+  getAvailableTags,
+  type GroupingRule,
+  type GroupingMatch,
+  type GroupingEmit,
+  type GroupingResult,
+  type GroupingEngineConfig,
+  type GroupingEngineStats,
+} from "./grouping-rules.js";
+
+// Significance rules
+export {
+  SignificanceEngine,
+  createSignificanceEngine,
+  defineSignificanceRule,
+  buildSignificanceContext,
+  builtinSignificanceRules,
+  criticalSignificanceRules,
+  importantSignificanceRules,
+  minorSignificanceRules,
+  hiddenSignificanceRules,
+  getSignificanceRulesByLevel,
+  getSignificanceRulesByDomain,
+  getSignificanceLevelValue,
+  compareSignificanceLevels,
+  type SignificanceRule,
+  type SignificanceMatch,
+  type SignificanceEmit,
+  type SignificanceResult,
+  type SignificanceLevel,
+  type SignificanceContext,
+  type SignificanceEngineConfig,
+  type SignificanceEngineStats,
+} from "./significance-rules.js";

--- a/packages/devac-core/src/rules/significance-rules.ts
+++ b/packages/devac-core/src/rules/significance-rules.ts
@@ -1,0 +1,807 @@
+/**
+ * Significance Rules - Architectural Importance Classification
+ *
+ * Rules for classifying effects by their architectural significance.
+ * Used to filter noise from C4 diagrams and highlight critical components.
+ *
+ * Significance Levels:
+ * - critical: Must appear in all diagrams (public API, heavy usage)
+ * - important: Should appear in container diagrams (domain logic)
+ * - minor: Only show in detailed views (helpers, utilities)
+ * - hidden: Never show (logging, debug, internal)
+ *
+ * Part of DevAC v3.0 Foundation.
+ */
+
+import type { EnrichedDomainEffect } from "../types/enriched-effects.js";
+import type { DomainEffect } from "./rule-engine.js";
+
+/**
+ * Significance level for effects
+ */
+export type SignificanceLevel = "critical" | "important" | "minor" | "hidden";
+
+/**
+ * Context for significance evaluation (aggregate stats)
+ */
+export interface SignificanceContext {
+  /** Total effects in the codebase */
+  totalEffects: number;
+  /** Effect counts by domain */
+  domainCounts: Record<string, number>;
+  /** Effect counts by action */
+  actionCounts: Record<string, number>;
+  /** Optional: Number of dependents per entity */
+  dependentCounts?: Map<string, number>;
+  /** Optional: Exported entity IDs */
+  exportedEntities?: Set<string>;
+}
+
+/**
+ * Match criteria for a significance rule
+ */
+export interface SignificanceMatch {
+  /** File path pattern (string for includes, RegExp for pattern) */
+  filePath?: string | RegExp;
+  /** Entity kind to match (function, class, method, etc.) */
+  entityKind?: string | string[];
+  /** Entity name pattern */
+  entityName?: string | RegExp;
+  /** Match effects in specific domain(s) */
+  domain?: string | string[];
+  /** Match effects with specific action(s) */
+  action?: string | string[];
+  /** Match exported entities only */
+  isExported?: boolean;
+  /** Match entities with minimum dependents */
+  minDependents?: number;
+  /** Custom predicate with context access */
+  predicate?: (
+    effect: DomainEffect | EnrichedDomainEffect,
+    context: SignificanceContext
+  ) => boolean;
+}
+
+/**
+ * What the significance rule emits when matched
+ */
+export interface SignificanceEmit {
+  /** Significance level */
+  level: SignificanceLevel;
+  /** Human-readable reason for this classification */
+  reason?: string;
+}
+
+/**
+ * A rule that classifies effects by significance
+ */
+export interface SignificanceRule {
+  /** Unique rule identifier */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Description of what this rule matches */
+  description?: string;
+  /** Match criteria */
+  match: SignificanceMatch;
+  /** Significance classification */
+  emit: SignificanceEmit;
+  /** Priority (higher = evaluated first) */
+  priority?: number;
+  /** Whether this rule is enabled */
+  enabled?: boolean;
+}
+
+/**
+ * Result of applying significance rules to an effect
+ */
+export interface SignificanceResult {
+  /** Original effect */
+  effect: DomainEffect | EnrichedDomainEffect;
+  /** Assigned significance level */
+  level: SignificanceLevel;
+  /** Rule that matched (null if default) */
+  ruleId: string | null;
+  /** Reason for this classification */
+  reason?: string;
+}
+
+/**
+ * Type guard to check if a DomainEffect is enriched
+ */
+function isEnrichedEffect(
+  effect: DomainEffect | EnrichedDomainEffect
+): effect is EnrichedDomainEffect {
+  return "sourceName" in effect && "relativeFilePath" in effect;
+}
+
+/**
+ * Get file path from effect (relative if enriched, absolute otherwise)
+ */
+function getEffectPath(effect: DomainEffect | EnrichedDomainEffect): string {
+  return isEnrichedEffect(effect) ? effect.relativeFilePath : effect.filePath;
+}
+
+/**
+ * Get entity name from effect (readable name if enriched)
+ */
+function getEffectName(effect: DomainEffect | EnrichedDomainEffect): string {
+  return isEnrichedEffect(effect) ? effect.sourceName : effect.sourceEntityId;
+}
+
+/**
+ * Get entity kind from effect (if enriched)
+ */
+function getEffectKind(effect: DomainEffect | EnrichedDomainEffect): string | undefined {
+  return isEnrichedEffect(effect) ? effect.sourceKind : undefined;
+}
+
+/**
+ * Check if a string matches a pattern (string or RegExp)
+ */
+function matchesPattern(value: string | null | undefined, pattern: string | RegExp): boolean {
+  if (value == null) return false;
+  if (typeof pattern === "string") {
+    return value.includes(pattern);
+  }
+  return pattern.test(value);
+}
+
+/**
+ * Check if a value is in an array (or matches if not array)
+ */
+function matchesArrayOrValue<T>(value: T, arrayOrValue: T | T[]): boolean {
+  if (Array.isArray(arrayOrValue)) {
+    return arrayOrValue.includes(value);
+  }
+  return value === arrayOrValue;
+}
+
+/**
+ * Check if an effect matches a significance rule's criteria
+ */
+function effectMatchesSignificanceRule(
+  effect: DomainEffect | EnrichedDomainEffect,
+  match: SignificanceMatch,
+  context: SignificanceContext
+): boolean {
+  // Check file path
+  if (match.filePath) {
+    const path = getEffectPath(effect);
+    if (!matchesPattern(path, match.filePath)) {
+      return false;
+    }
+  }
+
+  // Check entity kind (only for enriched effects)
+  if (match.entityKind) {
+    const kind = getEffectKind(effect);
+    if (kind === undefined) {
+      return false;
+    }
+    if (!matchesArrayOrValue(kind, match.entityKind)) {
+      return false;
+    }
+  }
+
+  // Check entity name
+  if (match.entityName) {
+    const name = getEffectName(effect);
+    if (!matchesPattern(name, match.entityName)) {
+      return false;
+    }
+  }
+
+  // Check domain
+  if (match.domain) {
+    if (!matchesArrayOrValue(effect.domain, match.domain)) {
+      return false;
+    }
+  }
+
+  // Check action
+  if (match.action) {
+    if (!matchesArrayOrValue(effect.action, match.action)) {
+      return false;
+    }
+  }
+
+  // Check exported status
+  if (match.isExported !== undefined) {
+    const isExported = context.exportedEntities?.has(effect.sourceEntityId) ?? false;
+    if (isExported !== match.isExported) {
+      return false;
+    }
+  }
+
+  // Check minimum dependents
+  if (match.minDependents !== undefined) {
+    const dependentCount = context.dependentCounts?.get(effect.sourceEntityId) ?? 0;
+    if (dependentCount < match.minDependents) {
+      return false;
+    }
+  }
+
+  // Run custom predicate if provided
+  if (match.predicate) {
+    if (!match.predicate(effect, context)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Utility to create a significance rule with defaults
+ */
+export function defineSignificanceRule(
+  rule: Omit<SignificanceRule, "enabled"> & { enabled?: boolean }
+): SignificanceRule {
+  return {
+    ...rule,
+    enabled: rule.enabled ?? true,
+    priority: rule.priority ?? 0,
+  };
+}
+
+// =============================================================================
+// Critical Significance Rules
+// =============================================================================
+
+/**
+ * Rules for CRITICAL components - must appear in all diagrams
+ */
+export const criticalSignificanceRules: SignificanceRule[] = [
+  defineSignificanceRule({
+    id: "sig-payment-operations",
+    name: "Payment Operations",
+    description: "Payment processing is always critical",
+    match: {
+      domain: "Payment",
+    },
+    emit: {
+      level: "critical",
+      reason: "Payment operations are business-critical",
+    },
+    priority: 100,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-auth-operations",
+    name: "Authentication Operations",
+    description: "Auth operations are security-critical",
+    match: {
+      domain: "Auth",
+    },
+    emit: {
+      level: "critical",
+      reason: "Authentication is security-critical",
+    },
+    priority: 100,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-high-dependents",
+    name: "Heavily Used Components",
+    description: "Components with many dependents are architecturally significant",
+    match: {
+      minDependents: 5,
+    },
+    emit: {
+      level: "critical",
+      reason: "Used by 5+ other components",
+    },
+    priority: 90,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-exported-api",
+    name: "Exported Public API",
+    description: "Exported functions are part of public API",
+    match: {
+      isExported: true,
+      entityKind: ["function", "class"],
+    },
+    emit: {
+      level: "critical",
+      reason: "Part of public API",
+    },
+    priority: 85,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-api-endpoints",
+    name: "API Endpoints",
+    description: "tRPC procedures and API handlers are entry points",
+    match: {
+      domain: "API",
+    },
+    emit: {
+      level: "critical",
+      reason: "API endpoint / entry point",
+    },
+    priority: 80,
+  }),
+];
+
+// =============================================================================
+// Important Significance Rules
+// =============================================================================
+
+/**
+ * Rules for IMPORTANT components - show in container diagrams
+ */
+export const importantSignificanceRules: SignificanceRule[] = [
+  defineSignificanceRule({
+    id: "sig-database-operations",
+    name: "Database Operations",
+    description: "Database access is important for understanding data flow",
+    match: {
+      domain: "Database",
+    },
+    emit: {
+      level: "important",
+      reason: "Data persistence operations",
+    },
+    priority: 60,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-messaging-operations",
+    name: "Messaging Operations",
+    description: "Message queues affect system architecture",
+    match: {
+      domain: "Messaging",
+    },
+    emit: {
+      level: "important",
+      reason: "Async messaging / event-driven",
+    },
+    priority: 60,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-storage-operations",
+    name: "Storage Operations",
+    description: "File/object storage operations",
+    match: {
+      domain: "Storage",
+    },
+    emit: {
+      level: "important",
+      reason: "File/object storage",
+    },
+    priority: 55,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-http-external",
+    name: "External HTTP Calls",
+    description: "External HTTP calls define system boundaries",
+    match: {
+      domain: "HTTP",
+    },
+    emit: {
+      level: "important",
+      reason: "External system integration",
+    },
+    priority: 55,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-moderate-dependents",
+    name: "Moderately Used Components",
+    description: "Components with some dependents",
+    match: {
+      minDependents: 2,
+    },
+    emit: {
+      level: "important",
+      reason: "Used by 2+ components",
+    },
+    priority: 50,
+  }),
+];
+
+// =============================================================================
+// Minor Significance Rules
+// =============================================================================
+
+/**
+ * Rules for MINOR components - only in detailed views
+ */
+export const minorSignificanceRules: SignificanceRule[] = [
+  defineSignificanceRule({
+    id: "sig-utility-files",
+    name: "Utility Files",
+    description: "Files in utility/helper directories",
+    match: {
+      filePath: /util(s|ity|ities)?[\/\-]|helper(s)?[\/\-]/i,
+    },
+    emit: {
+      level: "minor",
+      reason: "Utility / helper code",
+    },
+    priority: 30,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-utility-functions",
+    name: "Utility Functions",
+    description: "Functions with utility/helper naming patterns",
+    match: {
+      entityName: /^(get|set|is|has|format|parse|convert|transform|validate|normalize)/i,
+    },
+    emit: {
+      level: "minor",
+      reason: "Utility function pattern",
+    },
+    priority: 25,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-internal-only",
+    name: "Internal Only",
+    description: "Non-exported internal functions",
+    match: {
+      isExported: false,
+      entityKind: "function",
+    },
+    emit: {
+      level: "minor",
+      reason: "Internal implementation detail",
+    },
+    priority: 20,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-type-files",
+    name: "Type Definition Files",
+    description: "TypeScript type definition files",
+    match: {
+      filePath: /types?[\/\-]|\.d\.ts$/i,
+    },
+    emit: {
+      level: "minor",
+      reason: "Type definitions",
+    },
+    priority: 20,
+  }),
+];
+
+// =============================================================================
+// Hidden Significance Rules
+// =============================================================================
+
+/**
+ * Rules for HIDDEN components - never show in diagrams
+ */
+export const hiddenSignificanceRules: SignificanceRule[] = [
+  defineSignificanceRule({
+    id: "sig-console-logging",
+    name: "Console Logging",
+    description: "Console.log calls add noise to diagrams",
+    match: {
+      domain: "Observability",
+      action: "Log",
+      predicate: (effect) => {
+        const provider = effect.metadata?.provider;
+        return provider === "console";
+      },
+    },
+    emit: {
+      level: "hidden",
+      reason: "Console logging noise",
+    },
+    priority: 100,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-test-files",
+    name: "Test Files",
+    description: "Test files should not appear in architecture diagrams",
+    match: {
+      filePath: /\.(test|spec)\.(ts|js)x?$|__tests?__|__mocks?__/i,
+    },
+    emit: {
+      level: "hidden",
+      reason: "Test file",
+    },
+    priority: 100,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-debug-code",
+    name: "Debug Code",
+    description: "Debug utilities and code",
+    match: {
+      filePath: /debug[\/\-]/i,
+    },
+    emit: {
+      level: "hidden",
+      reason: "Debug code",
+    },
+    priority: 95,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-mock-files",
+    name: "Mock Files",
+    description: "Mock implementations for testing",
+    match: {
+      filePath: /mock(s)?[\/\-]|\.mock\./i,
+    },
+    emit: {
+      level: "hidden",
+      reason: "Mock implementation",
+    },
+    priority: 95,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-example-files",
+    name: "Example Files",
+    description: "Example and demo files",
+    match: {
+      filePath: /example(s)?[\/\-]|demo[\/\-]/i,
+    },
+    emit: {
+      level: "hidden",
+      reason: "Example / demo code",
+    },
+    priority: 90,
+  }),
+
+  defineSignificanceRule({
+    id: "sig-generated-files",
+    name: "Generated Files",
+    description: "Auto-generated files",
+    match: {
+      filePath: /generated[\/\-]|\.generated\./i,
+    },
+    emit: {
+      level: "hidden",
+      reason: "Generated code",
+    },
+    priority: 90,
+  }),
+];
+
+// =============================================================================
+// Combined Significance Rules
+// =============================================================================
+
+/**
+ * All builtin significance rules combined
+ */
+export const builtinSignificanceRules: SignificanceRule[] = [
+  ...criticalSignificanceRules,
+  ...importantSignificanceRules,
+  ...minorSignificanceRules,
+  ...hiddenSignificanceRules,
+];
+
+// =============================================================================
+// Significance Engine
+// =============================================================================
+
+/**
+ * Configuration for the significance engine
+ */
+export interface SignificanceEngineConfig {
+  /** Rules to apply */
+  rules: SignificanceRule[];
+  /** Default significance for unmatched effects */
+  defaultLevel?: SignificanceLevel;
+  /** Context for significance evaluation */
+  context?: Partial<SignificanceContext>;
+}
+
+/**
+ * Statistics from significance engine run
+ */
+export interface SignificanceEngineStats {
+  /** Total effects processed */
+  totalEffects: number;
+  /** Counts by significance level */
+  levelCounts: Record<SignificanceLevel, number>;
+  /** Rule match counts */
+  ruleStats: Map<string, number>;
+}
+
+/**
+ * Build significance context from effects
+ */
+export function buildSignificanceContext(
+  effects: (DomainEffect | EnrichedDomainEffect)[],
+  overrides?: Partial<SignificanceContext>
+): SignificanceContext {
+  const domainCounts: Record<string, number> = {};
+  const actionCounts: Record<string, number> = {};
+
+  for (const effect of effects) {
+    domainCounts[effect.domain] = (domainCounts[effect.domain] ?? 0) + 1;
+    actionCounts[effect.action] = (actionCounts[effect.action] ?? 0) + 1;
+  }
+
+  return {
+    totalEffects: effects.length,
+    domainCounts,
+    actionCounts,
+    dependentCounts: overrides?.dependentCounts,
+    exportedEntities: overrides?.exportedEntities,
+  };
+}
+
+/**
+ * Engine for applying significance rules to effects
+ */
+export class SignificanceEngine {
+  private rules: SignificanceRule[];
+  private defaultLevel: SignificanceLevel;
+  private baseContext: Partial<SignificanceContext>;
+
+  constructor(config: SignificanceEngineConfig) {
+    // Sort rules by priority (higher first)
+    this.rules = [...config.rules]
+      .filter((r) => r.enabled !== false)
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+    this.defaultLevel = config.defaultLevel ?? "minor";
+    this.baseContext = config.context ?? {};
+  }
+
+  /**
+   * Apply significance rules to a single effect
+   */
+  applyToEffect(
+    effect: DomainEffect | EnrichedDomainEffect,
+    context: SignificanceContext
+  ): SignificanceResult {
+    for (const rule of this.rules) {
+      if (effectMatchesSignificanceRule(effect, rule.match, context)) {
+        return {
+          effect,
+          level: rule.emit.level,
+          ruleId: rule.id,
+          reason: rule.emit.reason,
+        };
+      }
+    }
+
+    // No rule matched, use default
+    return {
+      effect,
+      level: this.defaultLevel,
+      ruleId: null,
+      reason: "No matching rule",
+    };
+  }
+
+  /**
+   * Apply significance rules to multiple effects
+   */
+  applyToEffects(effects: (DomainEffect | EnrichedDomainEffect)[]): {
+    results: SignificanceResult[];
+    stats: SignificanceEngineStats;
+  } {
+    // Build context from effects + base context
+    const context = buildSignificanceContext(effects, this.baseContext);
+
+    const results: SignificanceResult[] = [];
+    const ruleStats = new Map<string, number>();
+    const levelCounts: Record<SignificanceLevel, number> = {
+      critical: 0,
+      important: 0,
+      minor: 0,
+      hidden: 0,
+    };
+
+    // Initialize rule stats
+    for (const rule of this.rules) {
+      ruleStats.set(rule.id, 0);
+    }
+
+    for (const effect of effects) {
+      const result = this.applyToEffect(effect, context);
+      results.push(result);
+
+      // Update stats
+      levelCounts[result.level]++;
+      if (result.ruleId) {
+        ruleStats.set(result.ruleId, (ruleStats.get(result.ruleId) ?? 0) + 1);
+      }
+    }
+
+    return {
+      results,
+      stats: {
+        totalEffects: effects.length,
+        levelCounts,
+        ruleStats,
+      },
+    };
+  }
+
+  /**
+   * Filter effects by minimum significance level
+   */
+  filterByLevel(
+    effects: (DomainEffect | EnrichedDomainEffect)[],
+    minLevel: SignificanceLevel
+  ): (DomainEffect | EnrichedDomainEffect)[] {
+    const levelOrder: Record<SignificanceLevel, number> = {
+      critical: 4,
+      important: 3,
+      minor: 2,
+      hidden: 1,
+    };
+
+    const minLevelValue = levelOrder[minLevel];
+    const context = buildSignificanceContext(effects, this.baseContext);
+
+    return effects.filter((effect) => {
+      const result = this.applyToEffect(effect, context);
+      return levelOrder[result.level] >= minLevelValue;
+    });
+  }
+
+  /**
+   * Get all registered rules
+   */
+  getRules(): readonly SignificanceRule[] {
+    return this.rules;
+  }
+}
+
+/**
+ * Create a significance engine with the given configuration
+ */
+export function createSignificanceEngine(config: SignificanceEngineConfig): SignificanceEngine {
+  return new SignificanceEngine(config);
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * Get significance rules by level
+ */
+export function getSignificanceRulesByLevel(level: SignificanceLevel): SignificanceRule[] {
+  return builtinSignificanceRules.filter((rule) => rule.emit.level === level);
+}
+
+/**
+ * Get significance rules by domain
+ */
+export function getSignificanceRulesByDomain(domain: string): SignificanceRule[] {
+  return builtinSignificanceRules.filter((rule) => {
+    if (!rule.match.domain) return false;
+    if (Array.isArray(rule.match.domain)) {
+      return rule.match.domain.includes(domain);
+    }
+    return rule.match.domain === domain;
+  });
+}
+
+/**
+ * Numeric value for significance level (for comparisons)
+ */
+export function getSignificanceLevelValue(level: SignificanceLevel): number {
+  const levelOrder: Record<SignificanceLevel, number> = {
+    critical: 4,
+    important: 3,
+    minor: 2,
+    hidden: 1,
+  };
+  return levelOrder[level];
+}
+
+/**
+ * Compare two significance levels
+ * Returns positive if a > b, negative if a < b, 0 if equal
+ */
+export function compareSignificanceLevels(a: SignificanceLevel, b: SignificanceLevel): number {
+  return getSignificanceLevelValue(a) - getSignificanceLevelValue(b);
+}

--- a/packages/devac-core/src/views/gap-metrics.ts
+++ b/packages/devac-core/src/views/gap-metrics.ts
@@ -11,9 +11,13 @@
  * - External F1: External system recognition
  * - Composite Score: Weighted combination
  *
+ * Enhanced with grouping and significance rule analysis (v0.24).
+ *
  * @see docs/plans/gap-metrics.md
  */
 
+import type { GroupingRule } from "../rules/grouping-rules.js";
+import type { SignificanceRule } from "../rules/significance-rules.js";
 import type { LikeC4Relationship, ParsedC4Model } from "./likec4-json-parser.js";
 
 // =============================================================================
@@ -75,6 +79,75 @@ export interface GapAnalysis {
   compositeScore: number;
   /** Summary for display */
   summary: string;
+  /** Rule analysis results (if rules provided) */
+  ruleAnalysis?: RuleAnalysisResult;
+}
+
+/**
+ * Target thresholds for gap metrics
+ */
+export interface GapTargets {
+  containerF1: number;
+  signalToNoise: number;
+  relationshipF1: number;
+  externalF1: number;
+  composite: number;
+}
+
+/**
+ * Default target thresholds (from issue #161)
+ */
+export const DEFAULT_GAP_TARGETS: GapTargets = {
+  containerF1: 0.7,
+  signalToNoise: 0.5,
+  relationshipF1: 0.6,
+  externalF1: 0.7,
+  composite: 0.65,
+};
+
+/**
+ * Rule analysis result for grouping and significance
+ */
+export interface RuleAnalysisResult {
+  /** Grouping rules analysis */
+  grouping: {
+    /** Total containers identified by rules */
+    containersIdentified: number;
+    /** Container coverage by layer */
+    layerCoverage: Map<string, number>;
+    /** Rules that matched */
+    matchedRules: string[];
+    /** Unmatched items (not assigned to any container) */
+    unmatched: number;
+  };
+  /** Significance rules analysis */
+  significance: {
+    /** Effects by significance level */
+    byLevel: {
+      critical: number;
+      important: number;
+      minor: number;
+      hidden: number;
+    };
+    /** Rules that matched */
+    matchedRules: string[];
+    /** Filtering ratio (hidden / total) */
+    filteringRatio: number;
+  };
+}
+
+/**
+ * Options for gap analysis
+ */
+export interface GapAnalysisOptions {
+  /** Custom targets to compare against */
+  targets?: Partial<GapTargets>;
+  /** Grouping rules to analyze */
+  groupingRules?: GroupingRule[];
+  /** Significance rules to analyze */
+  significanceRules?: SignificanceRule[];
+  /** Show verbose output */
+  verbose?: boolean;
 }
 
 // =============================================================================
@@ -400,9 +473,14 @@ export function calculateExternalF1(validated: ParsedC4Model, generated: ParsedC
  *
  * @param validated - Human-validated architecture (goal)
  * @param generated - Machine-generated architecture (output)
+ * @param options - Analysis options including targets and rules
  * @returns Complete gap analysis with composite score
  */
-export function analyzeGap(validated: ParsedC4Model, generated: ParsedC4Model): GapAnalysis {
+export function analyzeGap(
+  validated: ParsedC4Model,
+  generated: ParsedC4Model,
+  options?: GapAnalysisOptions
+): GapAnalysis {
   const containerF1 = calculateContainerF1(validated, generated);
   const signalToNoise = calculateSignalToNoise(validated, generated);
   const relationshipF1 = calculateRelationshipF1(validated, generated);
@@ -415,15 +493,24 @@ export function analyzeGap(validated: ParsedC4Model, generated: ParsedC4Model): 
     WEIGHTS.relationshipF1 * relationshipF1.score +
     WEIGHTS.externalF1 * externalF1.score;
 
-  // Generate summary
+  // Analyze rules if provided
+  let ruleAnalysis: RuleAnalysisResult | undefined;
+  if (options?.groupingRules || options?.significanceRules) {
+    ruleAnalysis = analyzeRules(generated, options.groupingRules, options.significanceRules);
+  }
+
+  // Get targets for summary
+  const targets = { ...DEFAULT_GAP_TARGETS, ...options?.targets };
+
+  // Generate summary with target comparisons
   const summary = [
-    `Gap Score: ${(compositeScore * 100).toFixed(1)}%`,
+    `Gap Score: ${(compositeScore * 100).toFixed(1)}% (target: ${(targets.composite * 100).toFixed(0)}%)`,
     "",
     "Breakdown:",
-    `  Container F1: ${(containerF1.score * 100).toFixed(1)}% - ${containerF1.explanation}`,
-    `  Signal/Noise: ${(signalToNoise.score * 100).toFixed(1)}% - ${signalToNoise.explanation}`,
-    `  Relationship F1: ${(relationshipF1.score * 100).toFixed(1)}% - ${relationshipF1.explanation}`,
-    `  External F1: ${(externalF1.score * 100).toFixed(1)}% - ${externalF1.explanation}`,
+    `  Container F1: ${(containerF1.score * 100).toFixed(1)}% ${getTargetIndicator(containerF1.score, targets.containerF1)} - ${containerF1.explanation}`,
+    `  Signal/Noise: ${(signalToNoise.score * 100).toFixed(1)}% ${getTargetIndicator(signalToNoise.score, targets.signalToNoise)} - ${signalToNoise.explanation}`,
+    `  Relationship F1: ${(relationshipF1.score * 100).toFixed(1)}% ${getTargetIndicator(relationshipF1.score, targets.relationshipF1)} - ${relationshipF1.explanation}`,
+    `  External F1: ${(externalF1.score * 100).toFixed(1)}% ${getTargetIndicator(externalF1.score, targets.externalF1)} - ${externalF1.explanation}`,
     "",
     containerF1.details.missing.length > 0
       ? `Missing containers: ${containerF1.details.missing.join(", ")}`
@@ -442,18 +529,207 @@ export function analyzeGap(validated: ParsedC4Model, generated: ParsedC4Model): 
     externalF1,
     compositeScore,
     summary,
+    ruleAnalysis,
   };
+}
+
+/**
+ * Get target indicator for a metric
+ */
+function getTargetIndicator(score: number, target: number): string {
+  if (score >= target) {
+    return `(target: ${(target * 100).toFixed(0)}% ✓)`;
+  }
+  const gap = target - score;
+  return `(target: ${(target * 100).toFixed(0)}%, gap: ${(gap * 100).toFixed(1)}%)`;
+}
+
+/**
+ * Analyze grouping and significance rules against generated model
+ */
+function analyzeRules(
+  generated: ParsedC4Model,
+  groupingRules?: GroupingRule[],
+  significanceRules?: SignificanceRule[]
+): RuleAnalysisResult {
+  // Analyze grouping rules
+  const layerCoverage = new Map<string, number>();
+  const matchedGroupingRules = new Set<string>();
+  let containersIdentified = 0;
+  let unmatched = 0;
+
+  if (groupingRules && groupingRules.length > 0) {
+    // Check which containers could be identified by grouping rules
+    for (const container of generated.containers.values()) {
+      const containerName = container.title || container.id;
+      let matched = false;
+
+      for (const rule of groupingRules) {
+        if (matchesGroupingRule(containerName, rule)) {
+          matchedGroupingRules.add(rule.id);
+          matched = true;
+          containersIdentified++;
+
+          if (rule.emit.container) {
+            const current = layerCoverage.get(rule.emit.container) ?? 0;
+            layerCoverage.set(rule.emit.container, current + 1);
+          }
+          break;
+        }
+      }
+
+      if (!matched) {
+        unmatched++;
+      }
+    }
+  }
+
+  // Analyze significance rules (simulated based on component count)
+  const totalComponents = generated.components.size;
+  const byLevel = {
+    critical: 0,
+    important: 0,
+    minor: 0,
+    hidden: 0,
+  };
+  const matchedSignificanceRules = new Set<string>();
+
+  if (significanceRules && significanceRules.length > 0) {
+    // Distribute components across significance levels based on rules
+    // This is a heuristic since we don't have actual effect data here
+    for (const component of generated.components.values()) {
+      const componentName = component.title || component.id;
+      let assigned = false;
+
+      for (const rule of significanceRules) {
+        if (matchesSignificanceRule(componentName, rule)) {
+          matchedSignificanceRules.add(rule.id);
+          byLevel[rule.emit.level]++;
+          assigned = true;
+          break;
+        }
+      }
+
+      if (!assigned) {
+        byLevel.minor++; // Default to minor if no rule matches
+      }
+    }
+  } else {
+    // Default distribution if no rules provided
+    byLevel.minor = totalComponents;
+  }
+
+  const total = byLevel.critical + byLevel.important + byLevel.minor + byLevel.hidden;
+  const filteringRatio = total > 0 ? byLevel.hidden / total : 0;
+
+  return {
+    grouping: {
+      containersIdentified,
+      layerCoverage,
+      matchedRules: [...matchedGroupingRules],
+      unmatched,
+    },
+    significance: {
+      byLevel,
+      matchedRules: [...matchedSignificanceRules],
+      filteringRatio,
+    },
+  };
+}
+
+/**
+ * Check if a container name matches a grouping rule
+ */
+function matchesGroupingRule(containerName: string, rule: GroupingRule): boolean {
+  const lowerName = containerName.toLowerCase();
+
+  // Check file path pattern
+  if (rule.match.filePath) {
+    if (typeof rule.match.filePath === "string") {
+      if (lowerName.includes(rule.match.filePath.toLowerCase())) {
+        return true;
+      }
+    } else if (rule.match.filePath.test(containerName)) {
+      return true;
+    }
+  }
+
+  // Check entity name pattern
+  if (rule.match.entityName) {
+    if (typeof rule.match.entityName === "string") {
+      if (lowerName.includes(rule.match.entityName.toLowerCase())) {
+        return true;
+      }
+    } else if (rule.match.entityName.test(containerName)) {
+      return true;
+    }
+  }
+
+  // Check domain
+  if (rule.match.domain) {
+    const domains = Array.isArray(rule.match.domain) ? rule.match.domain : [rule.match.domain];
+    for (const domain of domains) {
+      if (lowerName.includes(domain.toLowerCase())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a component name matches a significance rule
+ */
+function matchesSignificanceRule(componentName: string, rule: SignificanceRule): boolean {
+  const lowerName = componentName.toLowerCase();
+
+  // Check entity name pattern
+  if (rule.match.entityName) {
+    if (typeof rule.match.entityName === "string") {
+      if (lowerName.includes(rule.match.entityName.toLowerCase())) {
+        return true;
+      }
+    } else if (rule.match.entityName.test(componentName)) {
+      return true;
+    }
+  }
+
+  // Check domain
+  if (rule.match.domain) {
+    const domains = Array.isArray(rule.match.domain) ? rule.match.domain : [rule.match.domain];
+    for (const domain of domains) {
+      if (lowerName.includes(domain.toLowerCase())) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 /**
  * Format gap analysis for terminal output
  */
-export function formatGapAnalysis(analysis: GapAnalysis): string {
-  const scoreBar = (score: number) => {
+export function formatGapAnalysis(
+  analysis: GapAnalysis,
+  options?: { targets?: Partial<GapTargets>; verbose?: boolean }
+): string {
+  const targets = { ...DEFAULT_GAP_TARGETS, ...options?.targets };
+
+  const scoreBar = (score: number, target?: number) => {
     const filled = Math.round(score * 20);
     const empty = 20 - filled;
-    return `[${"█".repeat(filled)}${"░".repeat(empty)}] ${(score * 100).toFixed(0)}%`;
+    const bar = `[${"█".repeat(filled)}${"░".repeat(empty)}] ${(score * 100).toFixed(0)}%`;
+    if (target !== undefined) {
+      const indicator = score >= target ? "✓" : `(gap: ${((target - score) * 100).toFixed(0)}%)`;
+      return `${bar} ${indicator}`;
+    }
+    return bar;
   };
+
+  const compositeIndicator =
+    analysis.compositeScore >= targets.composite ? "✓ ON TARGET" : "BELOW TARGET";
 
   const lines = [
     "═══════════════════════════════════════════════════════════",
@@ -461,25 +737,65 @@ export function formatGapAnalysis(analysis: GapAnalysis): string {
     "═══════════════════════════════════════════════════════════",
     "",
     `  COMPOSITE SCORE: ${scoreBar(analysis.compositeScore)}`,
+    `                   Target: ${(targets.composite * 100).toFixed(0)}% - ${compositeIndicator}`,
     "",
     "───────────────────────────────────────────────────────────",
-    "  BREAKDOWN:",
+    "  BREAKDOWN:                          Current    Target",
     "───────────────────────────────────────────────────────────",
     "",
-    `  Container F1:    ${scoreBar(analysis.containerF1.score)}`,
+    `  Container F1:    ${scoreBar(analysis.containerF1.score, targets.containerF1)}`,
     `                   ${analysis.containerF1.explanation}`,
     "",
-    `  Signal/Noise:    ${scoreBar(analysis.signalToNoise.score)}`,
+    `  Signal/Noise:    ${scoreBar(analysis.signalToNoise.score, targets.signalToNoise)}`,
     `                   ${analysis.signalToNoise.explanation}`,
     "",
-    `  Relationship F1: ${scoreBar(analysis.relationshipF1.score)}`,
+    `  Relationship F1: ${scoreBar(analysis.relationshipF1.score, targets.relationshipF1)}`,
     `                   ${analysis.relationshipF1.explanation}`,
     "",
-    `  External F1:     ${scoreBar(analysis.externalF1.score)}`,
+    `  External F1:     ${scoreBar(analysis.externalF1.score, targets.externalF1)}`,
     `                   ${analysis.externalF1.explanation}`,
     "",
     "═══════════════════════════════════════════════════════════",
   ];
+
+  // Add rule analysis if present
+  if (analysis.ruleAnalysis) {
+    lines.push("");
+    lines.push("───────────────────────────────────────────────────────────");
+    lines.push("  RULE ANALYSIS:");
+    lines.push("───────────────────────────────────────────────────────────");
+    lines.push("");
+
+    // Grouping rules
+    const grouping = analysis.ruleAnalysis.grouping;
+    lines.push("  Grouping Rules:");
+    lines.push(`    Containers identified: ${grouping.containersIdentified}`);
+    lines.push(`    Unmatched containers: ${grouping.unmatched}`);
+    if (grouping.layerCoverage.size > 0) {
+      lines.push("    Layer coverage:");
+      for (const [layer, count] of grouping.layerCoverage) {
+        lines.push(`      - ${layer}: ${count} containers`);
+      }
+    }
+    if (grouping.matchedRules.length > 0 && options?.verbose) {
+      lines.push(`    Matched rules: ${grouping.matchedRules.join(", ")}`);
+    }
+    lines.push("");
+
+    // Significance rules
+    const sig = analysis.ruleAnalysis.significance;
+    lines.push("  Significance Rules:");
+    lines.push(`    Critical: ${sig.byLevel.critical}`);
+    lines.push(`    Important: ${sig.byLevel.important}`);
+    lines.push(`    Minor: ${sig.byLevel.minor}`);
+    lines.push(`    Hidden: ${sig.byLevel.hidden}`);
+    lines.push(`    Filtering ratio: ${(sig.filteringRatio * 100).toFixed(1)}%`);
+    if (sig.matchedRules.length > 0 && options?.verbose) {
+      lines.push(`    Matched rules: ${sig.matchedRules.join(", ")}`);
+    }
+    lines.push("");
+    lines.push("═══════════════════════════════════════════════════════════");
+  }
 
   // Add details for items with gaps
   if (analysis.containerF1.details.missing.length > 0) {
@@ -501,5 +817,85 @@ export function formatGapAnalysis(analysis: GapAnalysis): string {
     }
   }
 
+  // Add improvement suggestions
+  lines.push("");
+  lines.push("───────────────────────────────────────────────────────────");
+  lines.push("  SUGGESTIONS:");
+  lines.push("───────────────────────────────────────────────────────────");
+
+  const suggestions = getImprovementSuggestions(analysis, targets);
+  for (const suggestion of suggestions) {
+    lines.push(`  • ${suggestion}`);
+  }
+
   return lines.join("\n");
+}
+
+/**
+ * Generate improvement suggestions based on gap analysis
+ */
+function getImprovementSuggestions(analysis: GapAnalysis, targets: GapTargets): string[] {
+  const suggestions: string[] = [];
+
+  // Container F1 suggestions
+  if (analysis.containerF1.score < targets.containerF1) {
+    if (analysis.containerF1.details.extra.length > 5) {
+      suggestions.push(
+        "Consider adding grouping rules to reduce container noise (too many granular containers)"
+      );
+    }
+    if (analysis.containerF1.details.missing.length > 0) {
+      suggestions.push(
+        `Add containers for: ${analysis.containerF1.details.missing.slice(0, 3).join(", ")}`
+      );
+    }
+  }
+
+  // Signal-to-noise suggestions
+  if (analysis.signalToNoise.score < targets.signalToNoise) {
+    suggestions.push(
+      "Add significance rules to filter implementation details from architecture view"
+    );
+  }
+
+  // Relationship F1 suggestions
+  if (analysis.relationshipF1.score < targets.relationshipF1) {
+    if (analysis.relationshipF1.details.missing.length > 0) {
+      suggestions.push(
+        "Missing key relationships - check that data flow edges are being generated"
+      );
+    }
+    if (analysis.relationshipF1.details.extra.length > 10) {
+      suggestions.push("Too many relationships - consider filtering by significance level");
+    }
+  }
+
+  // External F1 suggestions
+  if (analysis.externalF1.score < targets.externalF1) {
+    suggestions.push(
+      "Review external system detection rules - some externals may be uncategorized"
+    );
+  }
+
+  // Rule analysis suggestions
+  if (analysis.ruleAnalysis) {
+    if (
+      analysis.ruleAnalysis.grouping.unmatched > analysis.ruleAnalysis.grouping.containersIdentified
+    ) {
+      suggestions.push(
+        "Most containers are unmatched - add more grouping rules for your codebase patterns"
+      );
+    }
+    if (analysis.ruleAnalysis.significance.filteringRatio < 0.1) {
+      suggestions.push(
+        "Low filtering ratio - add hidden significance rules for logging, debug, and test utilities"
+      );
+    }
+  }
+
+  if (suggestions.length === 0) {
+    suggestions.push("All metrics are on target - architecture documentation is well-aligned");
+  }
+
+  return suggestions;
 }

--- a/packages/devac-core/src/views/index.ts
+++ b/packages/devac-core/src/views/index.ts
@@ -19,6 +19,9 @@ export {
   exportContainersToEnhancedLikeC4,
   sanitizeLikeC4Id,
   discoverDomainBoundaries,
+  // Rule-based filtering and grouping
+  applySignificanceFiltering,
+  applyGroupingRules,
   // Types
   type C4ExternalSystem,
   type C4Container,
@@ -104,4 +107,9 @@ export {
   type F1Score,
   type GapMetric,
   type GapAnalysis,
+  type GapTargets,
+  type GapAnalysisOptions,
+  type RuleAnalysisResult,
+  // Constants
+  DEFAULT_GAP_TARGETS,
 } from "./gap-metrics.js";

--- a/plugins/devac/skills/validate-architecture/SKILL.md
+++ b/plugins/devac/skills/validate-architecture/SKILL.md
@@ -176,7 +176,15 @@ Calculate gap metrics between validated and generated.
 ```bash
 devac architecture score -p packages/devac-core
 # Output: Gap Score: 42% (Container F1: 35%, Relationship F1: 50%, ...)
+
+# With rule analysis (shows grouping and significance breakdown)
+devac architecture score -p packages/devac-core --with-rules
+
+# Verbose output showing matched rules
+devac architecture score -p packages/devac-core --with-rules -v
 ```
+
+See [C4 Quality Rules](knowledge/c4-quality-rules.md) for metric definitions and targets.
 
 ### `devac architecture diff`
 Show structural differences between validated and generated.
@@ -618,6 +626,68 @@ These identifiers are **reserved in LikeC4** and cannot be used as element names
 - Target gap score: >65% (from ~28% baseline)
 - **Important**: The `validated/` directory must have its own `spec.c4` and `likec4.config.json` to avoid LikeC4 merge conflicts with `generated/`
 - **Avoid reserved keywords**: Don't use `views`, `model`, `specification` as element identifiers
+
+## Gap Analysis Workflow
+
+Use the gap metrics to systematically improve C4 documentation quality.
+
+### Step 1: Baseline Assessment
+
+```bash
+# Get current gap metrics
+devac architecture score -p packages/devac-core --with-rules
+```
+
+Review the output to understand:
+- **Composite Score**: Overall quality (target: >65%)
+- **Container F1**: Are logical layers recognized? (target: >70%)
+- **Signal-to-Noise**: Are implementation details filtered? (target: >50%)
+- **Relationship F1**: Are key data flows captured? (target: >60%)
+- **External F1**: Are external systems categorized? (target: >70%)
+
+### Step 2: Identify Improvement Areas
+
+Based on the gaps, prioritize:
+
+| Gap | Problem | Solution |
+|-----|---------|----------|
+| Low Container F1 | Too granular, no layer recognition | Add grouping rules |
+| Low Signal/Noise | All functions shown, no filtering | Add significance rules |
+| Low Relationship F1 | Missing data flow edges | Enhance effect domain rules |
+| Low External F1 | Externals uncategorized | Add provider patterns |
+
+### Step 3: Apply Rules
+
+```bash
+# Generate C4 with rule-based grouping
+devac c4 -p packages/devac-core --grouping rules
+
+# Or configure rules in package's .devac/config.json
+```
+
+### Step 4: Measure Improvement
+
+```bash
+# Re-run score to measure impact
+devac architecture score -p packages/devac-core --with-rules
+
+# Compare before/after composite scores
+```
+
+### Step 5: Iterate
+
+Continue refining rules until:
+- Composite score >65%
+- All individual metrics meet targets
+- Generated architecture matches validated structure
+
+### Quality Rules Reference
+
+See [C4 Quality Rules](knowledge/c4-quality-rules.md) for:
+- Metric definitions (M1-M4)
+- Built-in grouping rules (6 layers)
+- Built-in significance rules (4 levels)
+- Example improvement sessions
 
 ## Relationship Parity Checklist
 

--- a/plugins/devac/skills/validate-architecture/knowledge/c4-quality-rules.md
+++ b/plugins/devac/skills/validate-architecture/knowledge/c4-quality-rules.md
@@ -1,0 +1,237 @@
+# C4 Quality Rules
+
+Rules for evaluating and improving C4 architecture documentation quality.
+
+## Gap Metrics (M1-M4)
+
+The Architecture Documentation Improvement Loop uses these metrics to measure quality:
+
+### M1: Container F1 Score (Weight: 25%)
+
+**Target:** >70%
+
+Measures how well generated containers match validated containers.
+
+```
+Container F1 = 2 * (Precision * Recall) / (Precision + Recall)
+
+Where:
+- Precision = Matched Containers / Generated Containers
+- Recall = Matched Containers / Validated Containers
+```
+
+**Improvement strategies:**
+- Add grouping rules to combine granular directories into logical layers
+- Use naming patterns to identify architectural boundaries
+- Map file path patterns to containers (e.g., `src/parsers/**` -> "Analysis Layer")
+
+### M2: Signal-to-Noise Ratio (Weight: 45%)
+
+**Target:** >50%
+
+Measures how well the generator filters to architecturally-significant components vs implementation details.
+
+```
+Ideal: Generated Component Count ≈ Validated Component Count (within 50%)
+Score decreases as ratio deviates from 1.0
+```
+
+**Improvement strategies:**
+- Add significance rules to classify component importance
+- Filter "hidden" level components from architecture views
+- Mark exported public APIs as "critical"
+- Mark internal helpers as "minor"
+- Mark logging/debug as "hidden"
+
+### M3: Relationship F1 Score (Weight: 15%)
+
+**Target:** >60%
+
+Measures how well generated relationships match validated relationships.
+
+```
+Relationship F1 = 2 * (Precision * Recall) / (Precision + Recall)
+
+Normalized by source/target entity names (last segment)
+```
+
+**Improvement strategies:**
+- Ensure data flow edges are generated from effect patterns
+- Add relationship significance filtering
+- Use typed relationships (reads, writes, calls, queries)
+
+### M4: External F1 Score (Weight: 15%)
+
+**Target:** >70%
+
+Measures recognition of external systems (databases, APIs, file systems).
+
+```
+External F1 = 2 * (Precision * Recall) / (Precision + Recall)
+```
+
+**Improvement strategies:**
+- Define domain rules for external system detection
+- Categorize externals by type (database, api, storage, messaging)
+- Use provider patterns (stripe, aws, postgres, etc.)
+
+## Composite Score
+
+```
+Composite = 0.25 * M1 + 0.45 * M2 + 0.15 * M3 + 0.15 * M4
+Target: >65%
+```
+
+## Grouping Rules
+
+Grouping rules assign components to logical containers/layers:
+
+| Layer | Match Patterns | Example Files |
+|-------|---------------|---------------|
+| Analysis | parser, analyzer, semantic, resolver | `src/parsers/*.ts`, `src/semantic/*.ts` |
+| Storage | duckdb, parquet, seed, storage | `src/storage/*.ts` |
+| Federation | hub, registry, federation, workspace | `src/hub/*.ts`, `src/workspace/*.ts` |
+| API | mcp, cli, command, tool | `src/commands/*.ts` |
+| Rules | rule, engine, builtin | `src/rules/*.ts` |
+| Views | c4, diagram, plantuml, likec4 | `src/views/*.ts` |
+
+### Built-in Grouping Rules
+
+The following rules are available via `builtinGroupingRules`:
+
+```typescript
+// Analysis Layer
+{ id: "analysis-parser", match: /parser/i, container: "Analysis Layer" }
+{ id: "analysis-analyzer", match: /analyzer/i, container: "Analysis Layer" }
+{ id: "analysis-semantic", match: /semantic/i, container: "Analysis Layer" }
+
+// Storage Layer
+{ id: "storage-duckdb", match: /duckdb/i, container: "Storage Layer" }
+{ id: "storage-parquet", match: /parquet/i, container: "Storage Layer" }
+{ id: "storage-seed", match: /seed/i, container: "Storage Layer" }
+
+// Federation Layer
+{ id: "federation-hub", match: /hub/i, container: "Federation Layer" }
+{ id: "federation-registry", match: /registry/i, container: "Federation Layer" }
+
+// API Layer
+{ id: "api-mcp", match: /mcp/i, container: "API Layer" }
+{ id: "api-cli", match: /cli|command/i, container: "API Layer" }
+
+// Rules Layer
+{ id: "rules-engine", match: /rule.*engine/i, container: "Rules Layer" }
+{ id: "rules-builtin", match: /builtin.*rule/i, container: "Rules Layer" }
+
+// Views Layer
+{ id: "views-c4", match: /c4|diagram/i, container: "Views Layer" }
+{ id: "views-likec4", match: /likec4/i, container: "Views Layer" }
+```
+
+## Significance Rules
+
+Significance rules classify component architectural importance:
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| Critical | Exported public API, >5 dependents | `createRuleEngine`, `analyzePackage` |
+| Important | Domain entry points, significant effects | `parseTypeScript`, `writeParquet` |
+| Minor | Internal helpers, utility functions | `normalizePathComponent`, `formatOutput` |
+| Hidden | Logging, debug, test utilities | `console.log`, `logger.debug`, `testHelper` |
+
+### Built-in Significance Rules
+
+```typescript
+// Critical
+{ id: "critical-exported", match: { isExported: true }, level: "critical" }
+{ id: "critical-high-usage", match: { dependentCount: { min: 5 } }, level: "critical" }
+{ id: "critical-domain-entry", match: { domain: ["Database", "Auth", "Payment"] }, level: "critical" }
+
+// Important
+{ id: "important-effects", match: { hasEffects: true }, level: "important" }
+{ id: "important-public", match: { isPublic: true }, level: "important" }
+
+// Minor
+{ id: "minor-helper", match: /helper|util/i, level: "minor" }
+{ id: "minor-internal", match: { isInternal: true }, level: "minor" }
+
+// Hidden
+{ id: "hidden-logging", match: /log|debug|trace/i, level: "hidden" }
+{ id: "hidden-test", match: /test|mock|stub|fixture/i, level: "hidden" }
+{ id: "hidden-internal-detail", match: /_internal|_private/i, level: "hidden" }
+```
+
+## Using Rules in Gap Analysis
+
+Run the architecture score command with rules:
+
+```bash
+# Standard score
+devac architecture score -p packages/devac-core
+
+# With rule analysis
+devac architecture score -p packages/devac-core --with-rules
+
+# Verbose output showing matched rules
+devac architecture score -p packages/devac-core --with-rules -v
+```
+
+Output includes:
+- Gap metrics with target comparisons
+- Rule analysis showing container coverage
+- Significance distribution (critical/important/minor/hidden)
+- Improvement suggestions
+
+## Improvement Workflow
+
+1. **Baseline**: Run `devac architecture score -p <package>` to get current metrics
+2. **Identify gaps**: Check which metrics are below target
+3. **Add rules**: Create custom grouping/significance rules for your codebase
+4. **Regenerate**: Run `devac c4 -p <package>` with new rules
+5. **Measure**: Run score again to verify improvement
+6. **Iterate**: Repeat until composite score >65%
+
+## CLI Commands
+
+```bash
+# Check architecture status
+devac architecture status -p packages/devac-core
+
+# Calculate gap score with targets
+devac architecture score -p packages/devac-core
+
+# Calculate gap score with rule analysis
+devac architecture score -p packages/devac-core --with-rules
+
+# Show structural differences
+devac architecture diff -p packages/devac-core
+
+# Generate C4 with rule-based grouping
+devac c4 -p packages/devac-core --grouping rules
+```
+
+## Example Improvement Session
+
+```
+# Initial state
+$ devac architecture score -p packages/devac-core
+COMPOSITE SCORE: [████████░░░░░░░░░░░░] 28%
+  Container F1: 30% (target: 70%, gap: 40%)
+  Signal/Noise: 20% (target: 50%, gap: 30%)
+  Relationship F1: 25% (target: 60%, gap: 35%)
+  External F1: 35% (target: 70%, gap: 35%)
+
+# After adding grouping and significance rules
+$ devac architecture score -p packages/devac-core --with-rules
+COMPOSITE SCORE: [█████████████░░░░░░░] 68%
+  Container F1: 75% (target: 70% ✓)
+  Signal/Noise: 55% (target: 50% ✓)
+  Relationship F1: 65% (target: 60% ✓)
+  External F1: 72% (target: 70% ✓)
+```
+
+## References
+
+- [Gap Metrics Plan](../../../../../docs/plans/gap-metrics.md)
+- [Grouping Rules](../../../../../packages/devac-core/src/rules/grouping-rules.ts)
+- [Significance Rules](../../../../../packages/devac-core/src/rules/significance-rules.ts)
+- [C4 Generator](../../../../../packages/devac-core/src/views/c4-generator.ts)


### PR DESCRIPTION
## Summary

- Add `GroupingRule` interface with built-in layer rules (Analysis, Storage, Federation, API, Rules, Views)
- Add `SignificanceRule` interface for classifying architectural importance (critical, important, minor, hidden)
- Integrate rule-based grouping and significance filtering into C4 generator
- Enhance `devac architecture score` command with gap metrics, target comparisons, and rule analysis
- Add C4 quality rules documentation for validate-architecture skill

## Test plan

- [x] All existing tests pass (315 CLI tests, 79 worktree tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Run `devac architecture score -p packages/devac-core --with-rules` to verify rule analysis
- [ ] Run `devac architecture score -p packages/devac-core --show-targets` to verify target display

Closes #161

🤖 Generated with [Claude Code](https://claude.ai/code)