### PR TITLE
fix(core): include root package in workspace discovery

### DIFF
--- a/.changeset/fix-root-package-discovery.md
+++ b/.changeset/fix-root-package-discovery.md
@@ -1,0 +1,15 @@
+---
+"@pietgk/devac-core": patch
+---
+
+Fix package discovery to include root package in workspaces
+
+When analyzing repositories with workspace configurations (pnpm/npm/yarn) or fallback patterns (packages/*, apps/*, etc.), the root package was being excluded from discovery. This caused the main application code in repos like React Native apps to never be analyzed.
+
+**Before:** Only workspace packages were discovered, missing root `package.json`
+**After:** Root package is always included first if `package.json` exists
+
+This fix ensures:
+- Root package is discovered alongside workspace packages
+- No duplicates when workspace patterns match root directory
+- Backward compatible - repos without root `package.json` work as before


### PR DESCRIPTION
## Summary

- Fix package discovery to always include the root package when `package.json` exists
- Prevents root application code from being missed during analysis (e.g., React Native apps)
- Add tests for root package inclusion and edge cases

## Problem

When analyzing repositories with workspace configurations (pnpm/npm/yarn) or fallback patterns (`packages/*`, `apps/*`, etc.), the root package was being excluded from discovery. This caused the main application code in repos like React Native apps to never be analyzed.

**Before:** Only workspace packages were discovered, missing root `package.json`
**After:** Root package is always included first if `package.json` exists

## Changes

- `packages/devac-core/src/workspace/package-manager.ts` - Modified `discoverJSPackages()` to always check for root package first
- `packages/devac-core/__tests__/workspace/package-manager.test.ts` - Updated existing tests and added new edge case tests

## Test plan

- [x] All existing tests updated and passing
- [x] New tests added for:
  - Root package included alongside workspace packages
  - Root package included alongside fallback pattern packages  
  - No duplication when workspace pattern matches root
  - No root added when `package.json` doesn't exist
- [ ] Manual verification: `devac analyze --force` on app repo shows root package

Fixes #172

🤖 Generated with [Claude Code](https://claude.ai/code)