### PR TITLE
fix(worktree): make start command more robust

### DIFF
--- a/.changeset/start-issue-robustness.md
+++ b/.changeset/start-issue-robustness.md
@@ -1,0 +1,9 @@
+---
+"@pietgk/devac-worktree": patch
+---
+
+fix(worktree): make start command more robust
+
+- Fix `gh issue view` failing in parent directory mode by passing explicit repo context
+- Add uncommitted changes detection before creating worktrees to prevent broken/empty worktrees
+- Provide helpful error messages with stash instructions when uncommitted changes are detected


### PR DESCRIPTION
## Summary

- Fix `gh issue view` failing in parent directory mode by passing explicit repo context
- Add uncommitted changes detection before creating worktrees to prevent broken/empty worktrees
- Provide helpful error messages with stash instructions when uncommitted changes are detected

## Changes

**@pietgk/devac-worktree**
- Add `checkForUncommittedChanges()` helper function that reuses existing `checkWorktreeStatus()` 
- Fix `startFromParentDirectory()` to get GitHub repo context from first specified repo before fetching issue
- Integrate uncommitted changes check in all three code paths (parent directory, workspace, standard mode)

## Test Plan

- [x] Tests pass (79 tests)
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Build succeeds
- [x] Changeset included

Closes #175

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)