### PR TITLE
fix(worktree): require full issue ID format, remove legacy numeric-only support

### DIFF
--- a/.changeset/fix-worktree-silent-failure.md
+++ b/.changeset/fix-worktree-silent-failure.md
@@ -1,0 +1,11 @@
+---
+"@pietgk/devac-worktree": patch
+---
+
+Fix silent failure when running `devac-worktree start` with numeric-only issue IDs
+
+- Remove legacy numeric-only issue ID format support
+- Require full issue ID format: `gh<repoDirectoryName>-<issueNumber>`
+- Detect non-`gh` inputs as Jira format with "coming soon" message
+- Add clear error messages with format explanation
+- Update all documentation to reflect new requirements

--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ devac context review --focus security
 Issue-based git worktree workflow with Claude integration:
 
 ```bash
-# Create worktree and launch Claude for an issue (from inside a repo)
-devac-worktree start 123
+# Create worktree for an issue (use gh<repoDir>-<number> format)
+devac-worktree start ghvivief-123
 
 # Create worktrees in multiple sibling repos
-devac-worktree start 123 --also web --also shared
+devac-worktree start ghvivief-123 --also web --also shared
 
 # From a parent directory: create worktrees in specified repos
-devac-worktree start 123 --repos api,web,shared
+devac-worktree start ghvivief-123 --repos api,web,shared
 
 # List active worktrees
 devac-worktree list
@@ -199,12 +199,14 @@ devac-worktree list
 devac-worktree status
 
 # Resume work on existing worktree
-devac-worktree resume 123
+devac-worktree resume ghvivief-123
 
 # Clean up merged worktrees
-devac-worktree clean 123
+devac-worktree clean ghvivief-123
 devac-worktree clean-merged
 ```
+
+**Issue ID Format**: Use `gh<repoDirectoryName>-<issueNumber>` (e.g., `ghvivief-123`, `ghapi-42`). Non-`gh` inputs are assumed to be Jira format (support coming soon).
 
 **Parent Directory Workflow**: Use `--repos` when running from a parent directory to create worktrees in multiple repositories at once. Claude will launch in the parent directory for unified multi-repo development.
 

--- a/docs/adr/0014-worktree-claude-workflow.md
+++ b/docs/adr/0014-worktree-claude-workflow.md
@@ -45,15 +45,20 @@ Create a new `devac-worktree` CLI package that automates the git worktree + Clau
 
 ### Issue ID Format (Extended)
 
-The `<issue>` parameter supports two formats:
+The `<issue>` parameter requires the full issue ID format:
 
-**Full Issue ID (Recommended):**
 ```
-ghrepo-123
+gh<repoDirectoryName>-<issueNumber>
 ```
+
 - `gh` = GitHub source prefix
-- `repo` = repository name (e.g., `vivief`, `api`)
-- `123` = issue number
+- `repoDirectoryName` = repository DIRECTORY name (the folder name, NOT org/repo)
+- `issueNumber` = issue number
+
+**Examples:**
+- `ghvivief-123` → repo directory "vivief", issue #123
+- `ghapi-42` → repo directory "api", issue #42
+- `ghmonorepo-3.0-99` → repo directory "monorepo-3.0", issue #99
 
 This format enables workspace-aware operation - the CLI can be run from anywhere in the workspace and will:
 1. Find the workspace root (directory containing `.devac/` or multiple repos)
@@ -62,11 +67,7 @@ This format enables workspace-aware operation - the CLI can be run from anywhere
 4. Fetch issue details using the resolved owner/repo
 5. Create the worktree in the workspace
 
-**Legacy Numeric Format:**
-```
-123
-```
-Only works when inside the target repository. Maintained for backward compatibility.
+**Note:** Non-`gh` inputs are assumed to be Jira format (support coming soon).
 
 ### State Management
 
@@ -76,7 +77,7 @@ Only works when inside the target repository. Maintained for backward compatibil
 
 ### Workflow
 
-**From anywhere in workspace (recommended):**
+**From anywhere in workspace:**
 ```
 devac-worktree start ghvivief-42
   ├── Find workspace root
@@ -91,20 +92,10 @@ devac-worktree start ghvivief-42
 
 # ... developer works with Claude ...
 
-devac-worktree clean 42
+devac-worktree clean ghvivief-42
   ├── Verify PR is merged
   ├── Remove worktree
   └── Delete branch
-```
-
-**Legacy (from inside repo):**
-```
-cd ~/ws/vivief
-devac-worktree start 42
-  ├── Fetch issue #42 from GitHub (current repo)
-  ├── Create branch: 42-fix-login-bug
-  ├── Create worktree: ../vivief-42-fix-login-bug/
-  └── ... (same as above)
 ```
 
 ### Context Discovery (Extended)
@@ -138,11 +129,9 @@ Two modes for working across repositories:
 
 **`--also` Flag (Sibling Mode):**
 ```bash
-# Inside a repo, add worktrees in sibling repos
-cd ~/projects/api
-devac-worktree start 123 --also web --also shared
+# Add worktrees in sibling repos
+devac-worktree start ghapi-123 --also web --also shared
 ```
-- Use when already inside a repository
 - Creates worktrees in sibling directories
 - Claude launches in current repo's worktree
 
@@ -150,7 +139,7 @@ devac-worktree start 123 --also web --also shared
 ```bash
 # From parent directory, create worktrees in multiple repos
 cd ~/projects
-devac-worktree start 123 --repos api,web,shared
+devac-worktree start ghapi-123 --repos api,web,shared
 ```
 - Use when in a parent directory containing repos
 - Creates worktrees for all specified repos

--- a/docs/devac-worktree.md
+++ b/docs/devac-worktree.md
@@ -31,22 +31,24 @@ pnpm --filter @pietgk/devac-worktree exec devac-worktree --help
 Create a worktree for an issue and launch Claude CLI.
 
 ```bash
-devac-worktree start <issue-number> [options]
+devac-worktree start <issue-id> [options]
 
 Options:
   --skip-install      Skip dependency installation
-  --skip-claude       Skip launching Claude CLI
+  --new-session       Launch Claude CLI in the worktree
   --create-pr         Create a draft PR immediately
   --also <repo>       Also create worktree in sibling repo (repeatable)
   --repos <repos>     Create worktrees in specified repos (comma-separated, parent dir only)
   -v, --verbose       Verbose output
 
 Examples:
-  devac-worktree start 123
-  devac-worktree start 123 --skip-claude
-  devac-worktree start 123 --also web --also shared
-  devac-worktree start 123 --repos api,web,shared
+  devac-worktree start ghvivief-123
+  devac-worktree start ghvivief-123 --new-session
+  devac-worktree start ghvivief-123 --also web --also shared
+  devac-worktree start ghvivief-123 --repos api,web,shared
 ```
+
+**Issue ID Format:** `gh<repoDirectoryName>-<issueNumber>` (e.g., `ghvivief-123`, `ghapi-42`)
 
 **Workflow:**
 1. Fetches issue #123 from GitHub
@@ -151,15 +153,15 @@ Issue #123 Status: Add user authentication
 Resume work on an existing worktree.
 
 ```bash
-devac-worktree resume <issue-number> [options]
+devac-worktree resume <issue-id> [options]
 
 Options:
-  --skip-claude       Skip launching Claude CLI
+  --new-session       Launch Claude CLI in the worktree
   -v, --verbose       Verbose output
 
 Examples:
-  devac-worktree resume 123
-  devac-worktree resume 123 --skip-claude
+  devac-worktree resume ghvivief-123
+  devac-worktree resume ghvivief-123 --new-session
 ```
 
 **Workflow:**
@@ -175,17 +177,19 @@ Examples:
 Remove worktree after PR is merged.
 
 ```bash
-devac-worktree clean <issue-number> [options]
+devac-worktree clean <issue-id> [options]
 
 Options:
-  -f, --force         Force removal even if PR is not merged
+  -f, --force         Force removal (skip PR check AND remove with modified files)
+  --skip-pr-check     Skip the PR merged check only
   --keep-branch       Keep the git branch
+  -y, --yes           Skip confirmation prompts
   -v, --verbose       Verbose output
 
 Examples:
-  devac-worktree clean 123
-  devac-worktree clean 123 --force
-  devac-worktree clean 123 --keep-branch
+  devac-worktree clean ghvivief-123
+  devac-worktree clean ghvivief-123 --force
+  devac-worktree clean ghvivief-123 --keep-branch
 ```
 
 **Workflow:**
@@ -226,28 +230,26 @@ Examples:
 Standard workflow for working on an issue in one repository:
 
 ```bash
-# Start working on issue #123
-cd ~/projects/api
-devac-worktree start 123
+# Start working on issue #123 in api repo
+devac-worktree start ghapi-123
 
-# Claude CLI launches in ../api-123-feature/
+# Worktree created at ../api-123-feature/
 # ... work with Claude ...
 
 # Check status
 devac-worktree status
 
 # After PR is merged
-devac-worktree clean 123
+devac-worktree clean ghapi-123
 ```
 
 ### Multi-Repo Workflow (--also)
 
-Use when inside a repository and need to add worktrees in sibling repos:
+Use to create worktrees in sibling repos:
 
 ```bash
-# Start in the main repo
-cd ~/projects/api
-devac-worktree start 123 --also web --also shared
+# Start and also create worktrees in sibling repos
+devac-worktree start ghapi-123 --also web --also shared
 
 # Creates:
 #   ../api-123-feature/
@@ -265,7 +267,7 @@ Use when working from a parent directory containing multiple repos:
 ```bash
 # Start from parent directory (not inside any repo)
 cd ~/projects
-devac-worktree start 123 --repos api,web,shared
+devac-worktree start ghapi-123 --repos api,web,shared
 
 # Creates worktrees in all specified repos
 # Claude launches in parent directory (~/projects)
@@ -376,14 +378,14 @@ gh auth login
 
 Use resume instead:
 ```bash
-devac-worktree resume 123
+devac-worktree resume ghvivief-123
 ```
 
 ### "PR not merged" when cleaning
 
 Use `--force` to remove anyway:
 ```bash
-devac-worktree clean 123 --force
+devac-worktree clean ghvivief-123 --force
 ```
 
 ### "Not a git repository" with --repos

--- a/docs/implementation/context-discovery.md
+++ b/docs/implementation/context-discovery.md
@@ -125,8 +125,8 @@ devac context --json
 Creates worktrees in multiple repos simultaneously:
 
 ```bash
-# Start issue 123 in current repo AND sibling-repo
-devac-worktree start 123 --also sibling-repo --also another-repo
+# Start issue 123 in api repo AND sibling repos
+devac-worktree start ghapi-123 --also sibling-repo --also another-repo
 ```
 
 Implementation:

--- a/docs/vivief-workflow.md
+++ b/docs/vivief-workflow.md
@@ -671,7 +671,7 @@ When working on issues that span multiple repositories, use `devac-worktree` and
 ┌─────────────────────────────────────────────────────────────────┐
 │  1. START ISSUE                                                  │
 │  ─────────────────                                               │
-│  devac-worktree start 123 --repos api,web                        │
+│  devac-worktree start ghapi-123 --repos api,web                  │
 │  → Creates api-123-feature/ and web-123-feature/                 │
 │  → Claude launches in parent directory                           │
 └─────────────────────────────────────────────────────────────────┘
@@ -725,7 +725,7 @@ When working on issues that span multiple repositories, use `devac-worktree` and
 ┌─────────────────────────────────────────────────────────────────┐
 │  7. CLEANUP (after PRs merged)                                   │
 │  ──────────                                                      │
-│  devac-worktree clean 123                                        │
+│  devac-worktree clean ghapi-123                                  │
 │  → Checks all PRs are merged                                     │
 │  → Cleans all worktrees for issue #123                           │
 └─────────────────────────────────────────────────────────────────┘
@@ -743,15 +743,14 @@ When working on issues that span multiple repositories, use `devac-worktree` and
 ### Choosing --also vs --repos
 
 **Use `--also`** when:
-- You're already inside a git repository
-- You want to add worktrees to sibling repos incrementally
-- Example: `devac-worktree start 123 --also web`
+- You want to add worktrees to sibling repos
+- Example: `devac-worktree start ghapi-123 --also web`
 
 **Use `--repos`** when:
 - You're in a parent directory (not inside any repo)
 - You want to create all worktrees at once
 - You want Claude to work across all repos in a single session
-- Example: `devac-worktree start 123 --repos api,web,shared`
+- Example: `devac-worktree start ghapi-123 --repos api,web,shared`
 
 ### Parent Directory Commands
 

--- a/packages/devac-worktree/README.md
+++ b/packages/devac-worktree/README.md
@@ -61,29 +61,27 @@ devac-worktree --help
 
 ## Issue ID Format
 
-The `<issue>` parameter supports two formats:
+The `<issue>` parameter requires the full issue ID format:
 
-### Full Issue ID (Recommended)
-
-Format: `ghrepo-123` - Works from anywhere in the workspace
-
-- `gh` = GitHub source prefix
-- `repo` = repository name (e.g., `vivief`, `api`)
-- `123` = issue number
+```
+gh<repoDirectoryName>-<issueNumber>
+│ │                    │
+│ │                    └─ Issue number (e.g., 42, 123)
+│ │
+│ └─ Repository DIRECTORY name (the folder name, NOT org/repo)
+│    Examples: "vivief", "monorepo-3.0", "app"
+│
+└─ Source prefix: "gh" for GitHub
+```
 
 **Examples:**
 - `ghvivief-39` - Issue #39 in the vivief repo
 - `ghapi-123` - Issue #123 in the api repo
+- `ghmonorepo-3.0-42` - Issue #42 in the monorepo-3.0 repo
 
-### Legacy Numeric Format
-
-Format: `123` - Only works when inside the repository
-
-This is maintained for backward compatibility but requires you to be inside the target repository.
+**Note:** Non-`gh` inputs are assumed to be Jira format (support coming soon).
 
 ## Quick Start
-
-### From Anywhere in Workspace (Recommended)
 
 ```bash
 # Start working on issue #123 in vivief repo
@@ -93,16 +91,7 @@ devac-worktree start ghvivief-123
 devac-worktree status
 
 # After PR is merged
-devac-worktree clean 123
-```
-
-### From Inside a Repository (Legacy)
-
-```bash
-cd /path/to/vivief
-
-# Start working on issue #123
-devac-worktree start 123
+devac-worktree clean ghvivief-123
 ```
 
 ## Workspace Mode
@@ -126,8 +115,8 @@ cd ~/ws/vivief/packages/core && devac-worktree start ghvivief-42
 ## Multi-Repo Support
 
 ```bash
-# Create worktrees in sibling repos (from inside a repo)
-devac-worktree start 123 --also web --also shared
+# Create worktrees in sibling repos
+devac-worktree start ghvivief-123 --also web --also shared
 
 # Create worktrees in multiple repos (from parent directory)
 devac-worktree start ghvivief-123 --repos api,web,shared

--- a/plugins/devac/commands/start-issue.md
+++ b/plugins/devac/commands/start-issue.md
@@ -10,8 +10,40 @@ You are helping the user start work on a GitHub issue.
 
 ## Arguments
 
-- `<issue-id>`: Issue number (e.g., `42`) or full ID (e.g., `ghvivief-42`)
+- `<issue-id>`: Full issue ID in format `gh<repoDir>-<number>` (e.g., `ghvivief-42`)
 - `quick` (optional): Work in current directory with a branch instead of creating a worktree
+
+## Issue ID Format
+
+**IMPORTANT:** Always use the full issue ID format:
+
+```
+gh<repoDirectoryName>-<issueNumber>
+│ │                    │
+│ │                    └─ Issue number (e.g., 42, 123)
+│ │
+│ └─ Repository DIRECTORY name (the folder name, NOT org/repo)
+│    Examples: "vivief", "monorepo-3.0", "app"
+│
+└─ Source prefix: "gh" for GitHub
+```
+
+**Examples:**
+- `ghvivief-42` → repo directory "vivief", issue #42
+- `ghmonorepo-3.0-123` → repo directory "monorepo-3.0", issue #123
+- `ghapp-7` → repo directory "app", issue #7
+
+**Handling User Input:**
+
+| User Provides | What to Do |
+|--------------|------------|
+| `ghvivief-42` | Use as-is (GitHub format) |
+| `https://github.com/org/vivief/issues/42` | Extract → `ghvivief-42` |
+| `42` alone | Ask: "Which repo?" then form `gh<repoDir>-42` |
+| `CORE-123` or `core-123` (Jira-style) | CLI will show "Jira support coming soon" |
+| Any non-`gh` input | Assumed to be Jira, shows "coming soon" message |
+
+**Note:** The CLI assumes any input NOT starting with `gh` is a Jira ticket (support coming soon). Mixed case inputs are uppercased in the error message (e.g., `core-123` → `CORE-123`).
 
 ## Execution Logic
 
@@ -205,7 +237,7 @@ Creating plan file...
 ### Quick mode (branch in current dir)
 
 ```
-User: /devac:start-issue 42 quick
+User: /devac:start-issue ghvivief-42 quick
 
 Claude: Fetching issue #42...
 
@@ -220,7 +252,7 @@ Claude: Fetching issue #42...
 ### Already on issue branch
 
 ```
-User: /devac:start-issue 31 quick
+User: /devac:start-issue ghvivief-31 quick
 
 Claude: Fetching issue #31...
 


### PR DESCRIPTION
## Summary

- Remove legacy numeric-only issue ID format that caused silent failures when run outside a git repo
- Require full issue ID format: `gh<repoDirectoryName>-<issueNumber>` (e.g., `ghvivief-123`)
- Detect non-`gh` inputs as Jira format with "coming soon" message

## Changes

### Code Changes
- **`packages/devac-worktree/src/index.ts`**: Updated `parseIssueArg()` to check for `gh` prefix first, throw clear error for invalid GitHub format, assume Jira for non-`gh` inputs
- **`packages/devac-worktree/src/commands/start.ts`**: Made `issueId` and `repoName` required, removed ~180 lines of unreachable "normal mode" code
- **`packages/devac-worktree/__tests__/cli-args.test.ts`**: Updated tests for new Jira detection behavior

### Documentation Updates
- Updated `README.md`, `packages/devac-worktree/README.md`, `docs/devac-worktree.md`, `docs/adr/0014-worktree-claude-workflow.md`, `docs/vivief-workflow.md`, `docs/implementation/context-discovery.md`
- Updated skill instructions in `plugins/devac/commands/start-issue.md`
- Removed all "Legacy Numeric Format" references
- Added clear Issue ID Format explanations

## Test Plan

- [x] All tests pass (80/80 in devac-worktree)
- [x] `devac-worktree start 123` shows "Jira issue format detected: 123"
- [x] `devac-worktree start core-123` shows "Jira issue format detected: CORE-123"
- [x] `devac-worktree start ghvivief-42` works correctly
- [x] Documentation updated across all affected files

## Breaking Change

Numeric-only issue IDs (e.g., `123`) are no longer supported. Users must use the full format: `gh<repoDirectoryName>-<issueNumber>`.

Fixes #179

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)