### PR TITLE
fix: silence logger output in hook mode for clean JSON output

### DIFF
--- a/.changeset/fix-hook-mode-logger.md
+++ b/.changeset/fix-hook-mode-logger.md
@@ -1,0 +1,10 @@
+---
+"@pietgk/devac-cli": patch
+"@pietgk/devac-core": patch
+---
+
+Fix logger output in hook mode for clean JSON output
+
+- Add `setGlobalLogLevel("silent")` at start of `status --inject` command
+- Modify logger `shouldLog()` to respect global log level dynamically
+- Ensures hook JSON output is not polluted with PackageManager debug logs

--- a/packages/devac-cli/src/commands/status.ts
+++ b/packages/devac-cli/src/commands/status.ts
@@ -19,6 +19,7 @@ import {
   discoverContext,
   getCIStatusForContext,
   getWorkspaceStatus,
+  setGlobalLogLevel,
   syncCIStatusToHub,
 } from "@pietgk/devac-core";
 import type { Command } from "commander";
@@ -637,6 +638,11 @@ function formatSeedState(state: string): string {
  * Execute status command
  */
 export async function statusCommand(options: StatusOptions): Promise<StatusResult> {
+  // In inject mode, silence all logging to ensure clean JSON output
+  if (options.inject) {
+    setGlobalLogLevel("silent");
+  }
+
   const cwd = path.resolve(options.path);
   const seedsOnly = options.seedsOnly ?? false;
 

--- a/packages/devac-core/src/utils/logger.ts
+++ b/packages/devac-core/src/utils/logger.ts
@@ -125,6 +125,11 @@ class LoggerImpl implements Logger {
   }
 
   private shouldLog(level: LogLevel): boolean {
+    // If global level is "silent", silence all loggers regardless of instance level
+    // This allows setGlobalLogLevel("silent") to silence all loggers dynamically
+    if (globalLogLevel === "silent") {
+      return false;
+    }
     return LOG_LEVEL_PRIORITY[level] <= LOG_LEVEL_PRIORITY[this.level];
   }
 


### PR DESCRIPTION
## Summary

- Add `setGlobalLogLevel("silent")` at start of `status --inject` command
- Modify logger `shouldLog()` to check global level dynamically
- When `globalLogLevel` is "silent", all loggers are silenced
- Ensures hook JSON output is not polluted with PackageManager debug logs

## Test plan

- [x] `devac status --inject` outputs clean JSON (no debug logs)
- [x] `devac status --inject` is silent when no issues in hub
- [x] All existing logger tests pass
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)