### PR TITLE
feat(cli,mcp): reorganize into three core commands (v4.0)

### DIFF
--- a/.changeset/cli-three-command-reorganization.md
+++ b/.changeset/cli-three-command-reorganization.md
@@ -1,0 +1,38 @@
+---
+"@pietgk/devac-cli": major
+"@pietgk/devac-mcp": major
+---
+
+BREAKING: Reorganize CLI into three core commands (v4.0)
+
+This is a breaking change that consolidates 50+ CLI commands into three core commands:
+
+**New Command Structure:**
+- `devac sync` - Analyze packages, register repos, sync CI/issues/docs
+- `devac status` - Show health, diagnostics, doctor, seeds
+- `devac query <subcommand>` - All code graph queries
+
+Plus utility commands:
+- `devac mcp` - Start MCP server
+- `devac workflow` - CI/git integration
+
+**Command Mapping (old → new):**
+- `devac analyze` → `devac sync`
+- `devac hub init/register/refresh` → `devac sync` (automatic)
+- `devac validate` → `devac sync --validate`
+- `devac watch` → `devac sync --watch`
+- `devac find-symbol` → `devac query symbol`
+- `devac deps` → `devac query deps`
+- `devac diagnostics` → `devac status --diagnostics`
+- `devac doctor` → `devac status --doctor`
+
+**MCP Tool Renaming:**
+Tools renamed to match CLI pattern with `query_*` and `status_*` prefixes:
+- `find_symbol` → `query_symbol`
+- `get_dependencies` → `query_deps`
+- `get_validation_errors` → `status_diagnostics`
+- etc.
+
+**Migration:** No backwards compatibility - update scripts to use new commands.
+
+See ADR-0041 (CLI Command Structure) and ADR-0042 (MCP Tool Naming) for details.

--- a/docs/adr/0041-cli-command-structure.md
+++ b/docs/adr/0041-cli-command-structure.md
@@ -1,0 +1,137 @@
+# ADR 0041: CLI Command Structure (v4.0 Reorganization)
+
+## Status
+
+Accepted
+
+## Context
+
+DevAC CLI had grown to 50+ commands spread across multiple command groups (hub, workspace, architecture, etc.), making it difficult for users to discover and remember commands. Different concepts were scattered across different command names:
+
+**Before (v3.x):**
+- `devac analyze` - Analyze packages
+- `devac hub init/register/refresh/sync` - Hub operations
+- `devac workspace init/status/watch` - Workspace operations
+- `devac validate` - Run validation
+- `devac watch` - Watch mode
+- `devac find-symbol/deps/dependents/affected` - Query operations
+- `devac diagnostics` - Show diagnostics
+- `devac doctor` - Health checks
+- `devac status` - Status info
+
+This led to:
+1. Confusion about which command to use for related operations
+2. Too many top-level commands to remember
+3. Inconsistent mental model (some operations in `hub`, others standalone)
+
+## Decision
+
+Consolidate all commands into three core commands following a simple mental model:
+
+```
+devac sync     # Make data fresh (analyze, register, validate)
+devac status   # See what's happening (health, diagnostics, doctor)
+devac query    # Ask questions (symbol, deps, SQL, etc.)
+```
+
+Plus utility commands:
+- `devac mcp` - Start MCP server
+- `devac workflow` - CI/git integration
+
+### Command Mapping
+
+| Old Command | New Command |
+|-------------|-------------|
+| `devac analyze` | `devac sync` |
+| `devac hub init/register/refresh` | `devac sync` (automatic) |
+| `devac hub sync` | `devac sync --ci --issues` |
+| `devac workspace init/status` | `devac sync` / `devac status` |
+| `devac watch` | `devac sync --watch` |
+| `devac validate` | `devac sync --validate` |
+| `devac clean` | `devac sync --clean` |
+| `devac find-symbol` | `devac query symbol` |
+| `devac deps` | `devac query deps` |
+| `devac dependents` | `devac query dependents` |
+| `devac affected` | `devac query affected` |
+| `devac query <sql>` | `devac query sql <sql>` |
+| `devac diagnostics` | `devac status --diagnostics` |
+| `devac doctor` | `devac status --doctor` |
+| `devac verify` | `devac status --seeds --verify` |
+
+### Query Subcommands
+
+The `query` command has 13 subcommands:
+
+```
+devac query sql <query>        # Raw SQL
+devac query symbol <name>      # Find symbols
+devac query deps <entity>      # Dependencies
+devac query dependents <entity> # Reverse dependencies
+devac query file <path>        # File symbols
+devac query call-graph <entity> # Call graph
+devac query affected <files>   # Impact analysis
+devac query effects            # Code effects
+devac query repos              # List repos
+devac query c4 [level]         # C4 diagrams
+devac query context            # Workspace context
+devac query rules              # Rules engine
+devac query schema             # Database schema
+```
+
+### Status Flags
+
+The `status` command absorbs all status-related operations via flags:
+
+```
+devac status                   # Default summary
+devac status --brief           # One-liner
+devac status --full            # Full details
+devac status --diagnostics     # Validation errors
+devac status --hub             # Hub health
+devac status --seeds           # Seed freshness
+devac status --seeds --verify  # Verify integrity
+devac status --doctor          # Health checks
+devac status --doctor --fix    # Auto-fix issues
+devac status --changeset       # Changeset needed?
+```
+
+### Sync Flags
+
+The `sync` command handles all data synchronization:
+
+```
+devac sync                     # Smart sync based on context
+devac sync --validate          # With validation
+devac sync --watch             # Continuous mode
+devac sync --force             # Force full resync
+devac sync --clean             # Remove stale data first
+devac sync --ci --issues       # Include GitHub data
+devac sync --docs              # Generate documentation
+```
+
+## Consequences
+
+### Positive
+
+1. **Simpler Mental Model**: Three verbs to remember (sync, status, query)
+2. **Discoverable**: `--help` on each command shows all options
+3. **Consistent**: All queries under `query`, all status under `status`
+4. **Composable**: Flags can be combined (`--doctor --fix`)
+
+### Negative
+
+1. **Breaking Change**: Old commands no longer work
+2. **Learning Curve**: Existing users need to relearn commands
+3. **Longer Commands**: Some operations are now longer (e.g., `query symbol` vs `find-symbol`)
+
+### Migration
+
+No backwards compatibility layer was added per decision. Users should:
+1. Update scripts to use new commands
+2. Check `devac --help` for new command structure
+3. Use `devac status` as default entry point
+
+## Related
+
+- ADR-0042: MCP Tool Naming Conventions
+- [CLI README](../../packages/devac-cli/README.md)

--- a/docs/adr/0042-mcp-tool-naming-conventions.md
+++ b/docs/adr/0042-mcp-tool-naming-conventions.md
@@ -1,0 +1,126 @@
+# ADR 0042: MCP Tool Naming Conventions
+
+## Status
+
+Accepted
+
+## Context
+
+The MCP server exposed tools with inconsistent naming that didn't align with the CLI command structure:
+
+**Before (v3.x):**
+- `find_symbol` - Find symbols
+- `get_dependencies` - Get dependencies
+- `get_dependents` - Get dependents
+- `get_file_symbols` - Get file symbols
+- `get_affected` - Get affected files
+- `get_call_graph` - Get call graph
+- `query_sql` - Execute SQL
+- `get_schema` - Get schema
+- `list_repos` - List repos
+- `get_context` - Get context
+- `get_workspace_status` - Get workspace status
+- `get_validation_errors` - Get validation errors
+- etc.
+
+Issues:
+1. Mixed naming patterns (`find_`, `get_`, `list_`, `query_`)
+2. Didn't match CLI command structure
+3. Hard to discover related tools
+
+## Decision
+
+Adopt a `{category}_{action}` naming pattern that aligns with CLI commands:
+
+### Categories
+
+1. **`query_*`** - Tools for querying the code graph (matches `devac query`)
+2. **`status_*`** - Tools for status and diagnostics (matches `devac status`)
+
+### Complete Tool List
+
+#### Query Tools (14)
+
+| Tool | CLI Equivalent | Description |
+|------|----------------|-------------|
+| `query_symbol` | `query symbol` | Find symbols by name |
+| `query_deps` | `query deps` | Get dependencies |
+| `query_dependents` | `query dependents` | Get reverse dependencies |
+| `query_file` | `query file` | Get file symbols |
+| `query_affected` | `query affected` | Get affected files |
+| `query_call_graph` | `query call-graph` | Get call graph |
+| `query_sql` | `query sql` | Execute SQL |
+| `query_schema` | `query schema` | Get schema |
+| `query_repos` | `query repos` | List repos |
+| `query_context` | `query context` | Get context |
+| `query_effects` | `query effects` | Query effects |
+| `query_rules` | `query rules` | Run rules engine |
+| `query_rules_list` | `query rules --list` | List rules |
+| `query_c4` | `query c4` | Generate C4 diagrams |
+
+#### Status Tools (7)
+
+| Tool | CLI Equivalent | Description |
+|------|----------------|-------------|
+| `status` | `status` | Get workspace status |
+| `status_diagnostics` | `status --diagnostics` | Get validation errors |
+| `status_diagnostics_summary` | `status --diagnostics` | Get error summary |
+| `status_diagnostics_counts` | `status --diagnostics` | Get error counts |
+| `status_all_diagnostics` | `status --diagnostics` | All diagnostics |
+| `status_all_diagnostics_summary` | `status --diagnostics` | All diagnostics summary |
+| `status_all_diagnostics_counts` | `status --diagnostics` | All diagnostics counts |
+
+### Naming Rationale
+
+1. **Prefix by category**: Makes tools discoverable in sorted lists
+2. **Matches CLI**: AI assistants can map between CLI and MCP easily
+3. **Consistent underscores**: MCP convention (not camelCase)
+4. **Action-oriented**: Clear what each tool does
+
+### Tool Mapping (Old → New)
+
+| Old Name | New Name |
+|----------|----------|
+| `find_symbol` | `query_symbol` |
+| `get_dependencies` | `query_deps` |
+| `get_dependents` | `query_dependents` |
+| `get_file_symbols` | `query_file` |
+| `get_affected` | `query_affected` |
+| `get_call_graph` | `query_call_graph` |
+| `get_schema` | `query_schema` |
+| `list_repos` | `query_repos` |
+| `get_context` | `query_context` |
+| `get_workspace_status` | `status` |
+| `get_validation_errors` | `status_diagnostics` |
+| `get_validation_summary` | `status_diagnostics_summary` |
+| `get_validation_counts` | `status_diagnostics_counts` |
+| `get_all_diagnostics` | `status_all_diagnostics` |
+| `get_diagnostics_summary` | `status_all_diagnostics_summary` |
+| `get_diagnostics_counts` | `status_all_diagnostics_counts` |
+| `query_effects` | `query_effects` (unchanged) |
+| `run_rules` | `query_rules` |
+| `list_rules` | `query_rules_list` |
+| `generate_c4` | `query_c4` |
+
+## Consequences
+
+### Positive
+
+1. **Discoverable**: Tools grouped by prefix in autocomplete
+2. **Consistent**: All tools follow same pattern
+3. **CLI Alignment**: Easy to map between CLI and MCP commands
+4. **Self-documenting**: Category prefix indicates tool purpose
+
+### Negative
+
+1. **Breaking Change**: AI assistants using old names need updates
+2. **Longer Names**: Some tool names are longer
+
+### Migration
+
+MCP clients (Claude Code, etc.) will receive updated tool names automatically when the MCP server is updated. No backwards compatibility layer was added.
+
+## Related
+
+- ADR-0041: CLI Command Structure
+- [MCP README](../../packages/devac-mcp/README.md)

--- a/docs/spec/ramblings.md
+++ b/docs/spec/ramblings.md
@@ -6,6 +6,33 @@ Its in no way presenting the prompt used, they can be ramblings to set the conte
 
 can you do a very thorough check where th test chect to handle a bug
 
+i changed my mind and think option E is closer to what i think we need.
+      i want to research the idea of using
+      sync, status and query and map everything into those concepts
+      so a developer is working together with the llm
+      devac sync makes sure everything from its source is available for query.
+      devec status show what the current status is including the results from
+      validation so we know what diagnostics there are to address.
+      devac query enable us to find out anything we want to know about the system
+      so analyze is not needed (its in sync)
+      init is not needed its in sync.
+      so what would it meand if we add this idea into the mix.
+      make sure to add this idea as a conceptualised idea into the plan so we can use
+      it to explain a limited set and be smart because i think we can
+      so again take a thorough look with this idea added and make sure we have its
+      pros and cons and the gaps in the idea that needs addressing
+      
+      devac status --doctor --fix is good
+        devac dev is also good
+        regarding run and validation we have a bit of a catch to solve:
+        so either devac status --validation to trigger the validation pipeline (includes typecheck, lint, test, coverage,
+        and more as needed) or validation is included by default in devac status.
+        for example when running devac sync in a workspace with fresh checked out repos and no hub we could say workspace
+        validation gives diagnostic that we need to create the hub. so run typescript is not what we want the llm to start
+        we want to inject the diagnostics including typecheck and lint issues (with extended context as already part of the
+        diagnostic concept) does this make sense and can you you see how this matches your research as this could be a bug
+        that the diagnistics concept is understood as an very essential part of the development feedback loop
+        
 # e2e pages element 
 
 lets figure out how we combine the concepts tha browser-mcp can:

--- a/packages/devac-cli/__tests__/command-aliases.test.ts
+++ b/packages/devac-cli/__tests__/command-aliases.test.ts
@@ -1,12 +1,14 @@
 /**
- * Command Aliases Tests for DevAC CLI
+ * Command Structure Tests for DevAC CLI v4.0
  *
- * Tests that command aliases work correctly:
- * - analyze → extract
- * - validate → check
- * - workspace → ws
+ * Tests the three-command model:
+ * - sync: analyze packages, register repos, sync CI/issues/docs
+ * - status: workspace health, seeds, diagnostics, doctor
+ * - query: all code graph queries (symbol, deps, sql, etc.)
  *
- * Also tests the default action (devac with no args shows status)
+ * Plus utility commands:
+ * - mcp: MCP server for AI assistants
+ * - workflow: CI/git integration
  */
 
 import { execSync } from "node:child_process";
@@ -15,12 +17,12 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-describe("command aliases", () => {
+describe("CLI command structure (v4.0)", () => {
   let tempDir: string;
   const cliPath = path.resolve(__dirname, "../dist/index.js");
 
   beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(tmpdir(), "devac-alias-test-"));
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), "devac-cmd-test-"));
   });
 
   afterEach(async () => {
@@ -48,126 +50,222 @@ describe("command aliases", () => {
     }
   }
 
-  describe("analyze → extract alias", () => {
-    it("extract command shows same help as analyze", () => {
-      const analyzeHelp = runCli("analyze --help");
-      const extractHelp = runCli("extract --help");
-
-      expect(analyzeHelp.exitCode).toBe(0);
-      expect(extractHelp.exitCode).toBe(0);
-
-      // Both should mention "analyze|extract"
-      expect(analyzeHelp.stdout).toContain("analyze|extract");
-      expect(extractHelp.stdout).toContain("analyze|extract");
+  describe("main help shows three core commands", () => {
+    it("lists sync command", () => {
+      const help = runCli("--help");
+      expect(help.stdout).toContain("sync");
     });
 
-    it("extract command is listed in main help", () => {
+    it("lists status command", () => {
       const help = runCli("--help");
+      expect(help.stdout).toContain("status");
+    });
 
-      expect(help.stdout).toContain("analyze|extract");
+    it("lists query command", () => {
+      const help = runCli("--help");
+      expect(help.stdout).toContain("query");
+    });
+
+    it("lists mcp command", () => {
+      const help = runCli("--help");
+      expect(help.stdout).toContain("mcp");
+    });
+
+    it("lists workflow command", () => {
+      const help = runCli("--help");
+      expect(help.stdout).toContain("workflow");
     });
   });
 
-  describe("validate → check alias", () => {
-    it("check command shows same help as validate", () => {
-      const validateHelp = runCli("validate --help");
-      const checkHelp = runCli("check --help");
-
-      expect(validateHelp.exitCode).toBe(0);
-      expect(checkHelp.exitCode).toBe(0);
-
-      // Both should mention "validate|check"
-      expect(validateHelp.stdout).toContain("validate|check");
-      expect(checkHelp.stdout).toContain("validate|check");
-    });
-
-    it("check command is listed in main help", () => {
-      const help = runCli("--help");
-
-      expect(help.stdout).toContain("validate|check");
-    });
-  });
-
-  describe("workspace → ws alias", () => {
-    it("ws command shows same help as workspace", () => {
-      const workspaceHelp = runCli("workspace --help");
-      const wsHelp = runCli("ws --help");
-
-      expect(workspaceHelp.exitCode).toBe(0);
-      expect(wsHelp.exitCode).toBe(0);
-
-      // Both should mention "workspace|ws"
-      expect(workspaceHelp.stdout).toContain("workspace|ws");
-      expect(wsHelp.stdout).toContain("workspace|ws");
-    });
-
-    it("ws command is listed in main help", () => {
-      const help = runCli("--help");
-
-      expect(help.stdout).toContain("workspace|ws");
-    });
-
-    it("ws subcommands work (status)", () => {
-      const result = runCli("ws status --help");
-
+  describe("sync command", () => {
+    it("sync command is available", () => {
+      const result = runCli("sync --help");
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("status");
-    });
-  });
-
-  describe("merged workspace subcommands", () => {
-    it("workspace has register subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("register");
-    });
-
-    it("workspace has unregister subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("unregister");
-    });
-
-    it("workspace has list subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("list");
-    });
-
-    it("workspace has refresh subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("refresh");
-    });
-
-    it("workspace has sync subcommand", () => {
-      const result = runCli("workspace --help");
-
       expect(result.stdout).toContain("sync");
     });
 
-    it("workspace has ci subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("ci");
+    it("sync supports --validate flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--validate");
     });
 
-    it("workspace has issues subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("issues");
+    it("sync supports --ci flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--ci");
     });
 
-    it("workspace has review subcommand", () => {
-      const result = runCli("workspace --help");
-
-      expect(result.stdout).toContain("review");
+    it("sync supports --issues flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--issues");
     });
 
-    it("workspace has mcp subcommand", () => {
-      const result = runCli("workspace --help");
+    it("sync supports --docs flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--docs");
+    });
 
-      expect(result.stdout).toContain("mcp");
+    it("sync supports --watch flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--watch");
+    });
+
+    it("sync supports --force flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--force");
+    });
+
+    it("sync supports --clean flag", () => {
+      const result = runCli("sync --help");
+      expect(result.stdout).toContain("--clean");
+    });
+  });
+
+  describe("status command", () => {
+    it("status command is available", () => {
+      const result = runCli("status --help");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("status");
+    });
+
+    it("status supports --brief option", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--brief");
+    });
+
+    it("status supports --full option", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--full");
+    });
+
+    it("status supports --diagnostics flag", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--diagnostics");
+    });
+
+    it("status supports --doctor flag", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--doctor");
+    });
+
+    it("status supports --seeds flag", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--seeds");
+    });
+
+    it("status supports --hub flag", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--hub");
+    });
+
+    it("status supports --changeset flag", () => {
+      const result = runCli("status --help");
+      expect(result.stdout).toContain("--changeset");
+    });
+  });
+
+  describe("query command", () => {
+    it("query command is available", () => {
+      const result = runCli("query --help");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("query");
+    });
+
+    it("query has sql subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("sql");
+    });
+
+    it("query has symbol subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("symbol");
+    });
+
+    it("query has deps subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("deps");
+    });
+
+    it("query has dependents subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("dependents");
+    });
+
+    it("query has affected subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("affected");
+    });
+
+    it("query has file subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("file");
+    });
+
+    it("query has call-graph subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("call-graph");
+    });
+
+    it("query has effects subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("effects");
+    });
+
+    it("query has rules subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("rules");
+    });
+
+    it("query has c4 subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("c4");
+    });
+
+    it("query has context subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("context");
+    });
+
+    it("query has repos subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("repos");
+    });
+
+    it("query has schema subcommand", () => {
+      const result = runCli("query --help");
+      expect(result.stdout).toContain("schema");
+    });
+  });
+
+  describe("workflow command", () => {
+    it("workflow command is available", () => {
+      const result = runCli("workflow --help");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("workflow");
+    });
+
+    it("workflow has pre-commit subcommand", () => {
+      const result = runCli("workflow --help");
+      expect(result.stdout).toContain("pre-commit");
+    });
+
+    it("workflow has prepare-ship subcommand", () => {
+      const result = runCli("workflow --help");
+      expect(result.stdout).toContain("prepare-ship");
+    });
+
+    it("workflow has check-changeset subcommand", () => {
+      const result = runCli("workflow --help");
+      expect(result.stdout).toContain("check-changeset");
+    });
+
+    it("workflow has install-local subcommand", () => {
+      const result = runCli("workflow --help");
+      expect(result.stdout).toContain("install-local");
+    });
+
+    it("workflow has plugin-dev subcommand", () => {
+      const result = runCli("workflow --help");
+      expect(result.stdout).toContain("plugin-dev");
     });
   });
 
@@ -176,7 +274,6 @@ describe("command aliases", () => {
       const result = runCli("");
 
       // Should show some status output (not help)
-      // Status output typically contains workspace/hub info
       expect(result.exitCode).toBe(0);
       // Should not show the full help text
       expect(result.stdout).not.toContain("Usage: devac [options] [command]");
@@ -194,48 +291,6 @@ describe("command aliases", () => {
           output.includes("ok") ||
           output.includes("next")
       ).toBe(true);
-    });
-  });
-
-  describe("diagnostics command", () => {
-    it("diagnostics command is available", () => {
-      const result = runCli("diagnostics --help");
-
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("diagnostics");
-    });
-
-    it("diagnostics command is listed in main help", () => {
-      const help = runCli("--help");
-
-      expect(help.stdout).toContain("diagnostics");
-    });
-  });
-
-  describe("status command", () => {
-    it("status command is available", () => {
-      const result = runCli("status --help");
-
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("status");
-    });
-
-    it("status command supports --brief option", () => {
-      const result = runCli("status --help");
-
-      expect(result.stdout).toContain("--brief");
-    });
-
-    it("status command supports --full option", () => {
-      const result = runCli("status --help");
-
-      expect(result.stdout).toContain("--full");
-    });
-
-    it("status command is listed in main help", () => {
-      const help = runCli("--help");
-
-      expect(help.stdout).toContain("status");
     });
   });
 });

--- a/packages/devac-cli/src/commands/index.ts
+++ b/packages/devac-cli/src/commands/index.ts
@@ -11,7 +11,12 @@
 export { registerStatusCommand } from "./status.js";
 export { registerDiagnosticsCommand } from "./diagnostics.js";
 export { registerAnalyzeCommand } from "./analyze.js";
-export { registerQueryCommand } from "./query.js";
+// Query umbrella command (consolidates all query operations)
+export { registerQueryCommand } from "./query/index.js";
+export type { QuerySqlOptions, QuerySqlResult } from "./query/index.js";
+
+// Legacy: keep queryCommand for programmatic use
+// Note: registerQueryCommand is now from query/index.js, not query.js
 export { registerVerifyCommand } from "./verify.js";
 export { registerCleanCommand } from "./clean.js";
 export { registerWatchCommand } from "./watch.js";
@@ -296,7 +301,7 @@ export type { DoctorOptions, DoctorResult } from "./doctor.js";
 
 // Sync command (analyze + register workflow)
 export { syncCommand } from "./sync.js";
-export type { SyncOptions, SyncResult } from "./sync.js";
+export type { SyncOptions, SyncResult, SyncScope } from "./sync.js";
 
 // Doc-sync command (documentation generation)
 export { docSyncCommand } from "./doc-sync.js";

--- a/packages/devac-cli/src/commands/query/affected.ts
+++ b/packages/devac-cli/src/commands/query/affected.ts
@@ -1,0 +1,58 @@
+/**
+ * Query Affected Subcommand
+ *
+ * Analyze which files are affected by changes to specified files.
+ * Wraps the affected command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { affectedCommand } from "../affected.js";
+
+/**
+ * Register the affected subcommand under query
+ */
+export function registerQueryAffected(parent: Command): void {
+  parent
+    .command("affected <files...>")
+    .description("Find files affected by changes")
+    .option("-p, --package <path>", "Package path to analyze", process.cwd())
+    .option("-d, --max-depth <depth>", "Maximum traversal depth", "10")
+    .option("--format <format>", "Output format (json, list, tree)", "json")
+    .option("--json", "Output as JSON (shorthand for --format json)")
+    .action(async (files, options) => {
+      const format = options.json ? "json" : options.format;
+      const result = await affectedCommand({
+        packagePath: path.resolve(options.package),
+        changedFiles: files,
+        maxDepth: options.maxDepth ? Number.parseInt(options.maxDepth, 10) : undefined,
+        format,
+      });
+
+      if (result.success) {
+        switch (format) {
+          case "list":
+            for (const file of result.affectedFiles) {
+              console.log(`${file.filePath} (${file.impactLevel}, depth=${file.depth})`);
+            }
+            break;
+          case "tree":
+            console.log(`Changed symbols: ${result.changedSymbols.length}`);
+            for (const sym of result.changedSymbols) {
+              console.log(`  ${sym.kind} ${sym.name} (${sym.filePath})`);
+            }
+            console.log(`\nAffected files: ${result.totalAffected}`);
+            for (const file of result.affectedFiles) {
+              console.log(`  ${"  ".repeat(file.depth)}${file.filePath}`);
+            }
+            break;
+          default:
+            console.log(JSON.stringify(result, null, 2));
+        }
+        console.error(`\n(${result.analysisTimeMs}ms)`);
+      } else {
+        console.error(`✗ Analysis failed: ${result.error}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/c4.ts
+++ b/packages/devac-cli/src/commands/query/c4.ts
@@ -1,0 +1,110 @@
+/**
+ * Query C4 Subcommand
+ *
+ * Generate C4 architecture diagrams from domain effects.
+ * Wraps the c4 command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import {
+  c4ContainersCommand,
+  c4ContextCommand,
+  c4DomainsCommand,
+  c4ExternalsCommand,
+} from "../c4.js";
+
+/**
+ * Register the c4 subcommand under query
+ */
+export function registerQueryC4(parent: Command): void {
+  const c4 = parent.command("c4").description("Generate C4 architecture diagrams");
+
+  // Context level
+  c4.command("context")
+    .description("Generate C4 Context diagram")
+    .option("-p, --package <path>", "Package path")
+    .option("--system-name <name>", "System name for diagram", "System")
+    .option("--system-description <desc>", "System description")
+    .option("-l, --limit <count>", "Maximum effects to process", "1000")
+    .option("-o, --output <file>", "Output file for PlantUML")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await c4ContextCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        systemName: options.systemName,
+        systemDescription: options.systemDescription,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        output: options.output,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+
+  // Containers level
+  c4.command("containers")
+    .description("Generate C4 Container diagram")
+    .option("-p, --package <path>", "Package path")
+    .option("--system-name <name>", "System name for diagram", "System")
+    .option("--grouping <strategy>", "Grouping strategy (directory, package, flat)", "directory")
+    .option("-l, --limit <count>", "Maximum effects to process", "1000")
+    .option("-o, --output <file>", "Output file for PlantUML")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await c4ContainersCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        systemName: options.systemName,
+        grouping: options.grouping,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        output: options.output,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+
+  // Domains
+  c4.command("domains")
+    .description("Discover domain boundaries from effects")
+    .option("-p, --package <path>", "Package path")
+    .option("-l, --limit <count>", "Maximum effects to process", "1000")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await c4DomainsCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+
+  // External systems
+  c4.command("externals")
+    .description("List external systems from effects")
+    .option("-p, --package <path>", "Package path")
+    .option("-l, --limit <count>", "Maximum effects to process", "1000")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await c4ExternalsCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/call-graph.ts
+++ b/packages/devac-cli/src/commands/query/call-graph.ts
@@ -1,0 +1,39 @@
+/**
+ * Query Call-Graph Subcommand
+ *
+ * Get call graph (callers and/or callees) for a function.
+ * Wraps the call-graph command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { callGraphCommand } from "../call-graph.js";
+
+/**
+ * Register the call-graph subcommand under query
+ */
+export function registerQueryCallGraph(parent: Command): void {
+  parent
+    .command("call-graph <entityId>")
+    .description("Get call graph for a function")
+    .option("-p, --package <path>", "Query single package only")
+    .option("-d, --direction <dir>", "Direction (callers, callees, both)", "both")
+    .option("--max-depth <depth>", "Maximum traversal depth", "3")
+    .option("-l, --limit <count>", "Maximum results per direction", "100")
+    .option("--json", "Output as JSON")
+    .action(async (entityId, options) => {
+      const result = await callGraphCommand({
+        entityId,
+        direction: options.direction as "callers" | "callees" | "both",
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        maxDepth: options.maxDepth ? Number.parseInt(options.maxDepth, 10) : undefined,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/context.ts
+++ b/packages/devac-cli/src/commands/query/context.ts
@@ -1,0 +1,119 @@
+/**
+ * Query Context Subcommand
+ *
+ * Discover cross-repository context including CI status and issues.
+ * Wraps the context command functionality.
+ */
+
+import type { Command } from "commander";
+import { contextCICommand, contextCommand, contextIssuesCommand } from "../context.js";
+
+/**
+ * Register the context subcommand under query
+ */
+export function registerQueryContext(parent: Command): void {
+  const context = parent.command("context").description("Discover cross-repository context");
+
+  // Main context discovery
+  context
+    .command("discover")
+    .description("Discover current working context")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await contextCommand({
+        cwd: process.cwd(),
+        format: options.json ? "json" : "text",
+      });
+
+      if (result.success) {
+        if (options.json) {
+          console.log(JSON.stringify(result.context, null, 2));
+        } else {
+          console.log(result.formatted);
+        }
+      } else {
+        console.error(`✗ ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // CI status
+  context
+    .command("ci")
+    .description("Get CI status for all repos/worktrees")
+    .option("--include-checks", "Include individual check details")
+    .option("--sync-to-hub", "Sync CI status to central hub")
+    .option("--failing-only", "Only sync failing checks (with --sync-to-hub)")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await contextCICommand({
+        cwd: process.cwd(),
+        format: options.json ? "json" : "text",
+        includeChecks: options.includeChecks,
+        syncToHub: options.syncToHub,
+        failingOnly: options.failingOnly,
+      });
+
+      if (result.success) {
+        if (options.json) {
+          console.log(
+            JSON.stringify({ result: result.result, syncResult: result.syncResult }, null, 2)
+          );
+        } else {
+          console.log(result.formatted);
+        }
+      } else {
+        console.error(`✗ ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // Issues
+  context
+    .command("issues")
+    .description("Get GitHub issues for context")
+    .option("--open-only", "Only fetch open issues (default)", true)
+    .option("--all", "Fetch all issues (open and closed)")
+    .option("-l, --limit <count>", "Maximum issues per repo", "20")
+    .option("--sync-to-hub", "Sync issues to central hub")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await contextIssuesCommand({
+        cwd: process.cwd(),
+        format: options.json ? "json" : "text",
+        issuesOptions: {
+          openOnly: options.all ? false : options.openOnly,
+          limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        },
+        syncToHub: options.syncToHub,
+      });
+
+      if (result.success) {
+        if (options.json) {
+          console.log(
+            JSON.stringify({ result: result.result, syncResult: result.syncResult }, null, 2)
+          );
+        } else {
+          console.log(result.formatted);
+        }
+      } else {
+        console.error(`✗ ${result.error}`);
+        process.exit(1);
+      }
+    });
+
+  // Default action - show discover
+  context.action(async () => {
+    const result = await contextCommand({
+      cwd: process.cwd(),
+      format: "text",
+    });
+
+    if (result.success) {
+      console.log(result.formatted);
+    } else {
+      console.error(`✗ ${result.error}`);
+      process.exit(1);
+    }
+  });
+}

--- a/packages/devac-cli/src/commands/query/dependents.ts
+++ b/packages/devac-cli/src/commands/query/dependents.ts
@@ -1,0 +1,37 @@
+/**
+ * Query Dependents Subcommand
+ *
+ * Get incoming dependencies (reverse edges) to an entity.
+ * Wraps the dependents command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { dependentsCommand } from "../dependents.js";
+
+/**
+ * Register the dependents subcommand under query
+ */
+export function registerQueryDependents(parent: Command): void {
+  parent
+    .command("dependents <entityId>")
+    .description("Get dependents of an entity (reverse dependencies)")
+    .option("-p, --package <path>", "Query single package only")
+    .option("-t, --type <type>", "Filter by edge type (CALLS, IMPORTS, EXTENDS, etc.)")
+    .option("-l, --limit <count>", "Maximum results", "100")
+    .option("--json", "Output as JSON")
+    .action(async (entityId, options) => {
+      const result = await dependentsCommand({
+        entityId,
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        edgeType: options.type,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/deps.ts
+++ b/packages/devac-cli/src/commands/query/deps.ts
@@ -1,0 +1,37 @@
+/**
+ * Query Deps Subcommand
+ *
+ * Get outgoing dependencies (edges) from an entity.
+ * Wraps the deps command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { depsCommand } from "../deps.js";
+
+/**
+ * Register the deps subcommand under query
+ */
+export function registerQueryDeps(parent: Command): void {
+  parent
+    .command("deps <entityId>")
+    .description("Get dependencies of an entity")
+    .option("-p, --package <path>", "Query single package only")
+    .option("-t, --type <type>", "Filter by edge type (CALLS, IMPORTS, EXTENDS, etc.)")
+    .option("-l, --limit <count>", "Maximum results", "100")
+    .option("--json", "Output as JSON")
+    .action(async (entityId, options) => {
+      const result = await depsCommand({
+        entityId,
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        edgeType: options.type,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/effects.ts
+++ b/packages/devac-cli/src/commands/query/effects.ts
@@ -1,0 +1,44 @@
+/**
+ * Query Effects Subcommand
+ *
+ * Query code effects (function calls, store operations, etc.) extracted during analysis.
+ * Wraps the effects command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { effectsCommand } from "../effects.js";
+
+/**
+ * Register the effects subcommand under query
+ */
+export function registerQueryEffects(parent: Command): void {
+  parent
+    .command("effects")
+    .description("Query code effects (function calls, store operations, etc.)")
+    .option("-p, --package <path>", "Query single package only")
+    .option("-t, --type <type>", "Filter by effect type (FunctionCall, Store, etc.)")
+    .option("-f, --file <path>", "Filter by file path (partial match)")
+    .option("-e, --entity <id>", "Filter by source entity ID")
+    .option("--external", "Show only external calls")
+    .option("--async", "Show only async calls")
+    .option("-l, --limit <count>", "Maximum results", "100")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await effectsCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        type: options.type,
+        file: options.file,
+        entity: options.entity,
+        externalOnly: options.external,
+        asyncOnly: options.async,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/file.ts
+++ b/packages/devac-cli/src/commands/query/file.ts
@@ -1,0 +1,37 @@
+/**
+ * Query File Subcommand
+ *
+ * Get all symbols defined in a specific file.
+ * Wraps the file-symbols command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { fileSymbolsCommand } from "../file-symbols.js";
+
+/**
+ * Register the file subcommand under query
+ */
+export function registerQueryFile(parent: Command): void {
+  parent
+    .command("file <filePath>")
+    .description("Get all symbols defined in a file")
+    .option("-p, --package <path>", "Query single package only")
+    .option("-k, --kind <kind>", "Filter by symbol kind")
+    .option("-l, --limit <count>", "Maximum results", "100")
+    .option("--json", "Output as JSON")
+    .action(async (filePath, options) => {
+      const result = await fileSymbolsCommand({
+        filePath,
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        kind: options.kind,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/index.ts
+++ b/packages/devac-cli/src/commands/query/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Query Command Umbrella
+ *
+ * Consolidates all query operations under a single `devac query` command.
+ * Part of DevAC v4.0 Three Commands Reorganization.
+ */
+
+import type { Command } from "commander";
+import { registerQueryAffected } from "./affected.js";
+import { registerQueryC4 } from "./c4.js";
+import { registerQueryCallGraph } from "./call-graph.js";
+import { registerQueryContext } from "./context.js";
+import { registerQueryDependents } from "./dependents.js";
+import { registerQueryDeps } from "./deps.js";
+import { registerQueryEffects } from "./effects.js";
+import { registerQueryFile } from "./file.js";
+import { registerQueryRepos } from "./repos.js";
+import { registerQueryRules } from "./rules.js";
+import { registerQuerySchema } from "./schema.js";
+import { registerQuerySql } from "./sql.js";
+import { registerQuerySymbol } from "./symbol.js";
+
+/**
+ * Register the query command umbrella with all subcommands
+ */
+export function registerQueryCommand(program: Command): void {
+  const query = program
+    .command("query")
+    .description("Query the code graph")
+    .action(() => {
+      // Show help when no subcommand is provided
+      query.help();
+    });
+
+  // Default: raw SQL (as a subcommand)
+  registerQuerySql(query);
+
+  // Subcommands
+  registerQuerySymbol(query);
+  registerQueryDeps(query);
+  registerQueryDependents(query);
+  registerQueryFile(query);
+  registerQueryCallGraph(query);
+  registerQueryAffected(query);
+  registerQueryEffects(query);
+  registerQueryRepos(query);
+  registerQueryC4(query);
+  registerQueryContext(query);
+  registerQueryRules(query);
+  registerQuerySchema(query);
+}
+
+// Re-export subcommand types for programmatic use
+export type { QuerySqlOptions, QuerySqlResult } from "./sql.js";

--- a/packages/devac-cli/src/commands/query/repos.ts
+++ b/packages/devac-cli/src/commands/query/repos.ts
@@ -1,0 +1,60 @@
+/**
+ * Query Repos Subcommand
+ *
+ * List all repositories registered with the hub.
+ * Wraps the hub-list command functionality.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Command } from "commander";
+import { hubList } from "../hub-list.js";
+import { formatOutput } from "../output-formatter.js";
+
+/**
+ * Register the repos subcommand under query
+ */
+export function registerQueryRepos(parent: Command): void {
+  parent
+    .command("repos")
+    .description("List registered repositories")
+    .option("--hub-dir <path>", "Hub directory path", path.join(os.homedir(), ".devac"))
+    .option("-v, --verbose", "Show detailed output")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await hubList({
+        hubDir: options.hubDir,
+        json: options.json,
+        verbose: options.verbose,
+      });
+
+      if (result.success) {
+        if (options.json) {
+          console.log(
+            formatOutput({ repos: result.repos, count: result.repos.length }, { json: true })
+          );
+        } else {
+          console.log(result.message);
+          if (result.repos.length > 0) {
+            console.log("");
+            for (const repo of result.repos) {
+              if (options.verbose) {
+                console.log(`  ${repo.repoId}`);
+                console.log(`    Path: ${repo.localPath}`);
+                console.log(`    Status: ${repo.status}`);
+                console.log(`    Packages: ${repo.packages}`);
+                if (repo.lastSynced) {
+                  console.log(`    Last Sync: ${repo.lastSynced}`);
+                }
+              } else {
+                console.log(`  ${repo.repoId} (${repo.packages} packages)`);
+              }
+            }
+          }
+        }
+      } else {
+        console.error(`✗ ${result.error}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/rules.ts
+++ b/packages/devac-cli/src/commands/query/rules.ts
@@ -1,0 +1,89 @@
+/**
+ * Query Rules Subcommand
+ *
+ * Run the rules engine on effects to produce domain effects.
+ * Wraps the rules command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { rulesListCommand, rulesRunCommand, rulesStatsCommand } from "../rules.js";
+
+/**
+ * Register the rules subcommand under query
+ */
+export function registerQueryRules(parent: Command): void {
+  const rules = parent.command("rules").description("Run rules engine on effects");
+
+  // Run rules
+  rules
+    .command("run")
+    .description("Process effects through rules engine")
+    .option("-p, --package <path>", "Package path")
+    .option("-d, --domain <domain>", "Filter output by domain")
+    .option("-l, --limit <count>", "Maximum effects to process", "1000")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await rulesRunCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        domain: options.domain,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+
+  // List rules
+  rules
+    .command("list")
+    .description("List available rules")
+    .option("-d, --domain <domain>", "Filter by domain (e.g., Payment, Auth)")
+    .option("--provider <provider>", "Filter by provider (e.g., stripe, aws)")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await rulesListCommand({
+        domain: options.domain,
+        provider: options.provider,
+        json: options.json,
+      });
+
+      console.log(result.output);
+    });
+
+  // Stats
+  rules
+    .command("stats")
+    .description("Show rule match statistics")
+    .option("-p, --package <path>", "Package path")
+    .option("-l, --limit <count>", "Maximum effects to process", "1000")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await rulesStatsCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+
+  // Default action - run rules
+  rules.action(async () => {
+    const result = await rulesRunCommand({
+      limit: 1000,
+      json: false,
+    });
+
+    console.log(result.output);
+    if (!result.success) {
+      process.exit(1);
+    }
+  });
+}

--- a/packages/devac-cli/src/commands/query/schema.ts
+++ b/packages/devac-cli/src/commands/query/schema.ts
@@ -1,0 +1,188 @@
+/**
+ * Query Schema Subcommand
+ *
+ * Get available tables and columns in the code graph database.
+ * Useful for discovering the schema before writing SQL queries.
+ */
+
+import * as path from "node:path";
+import {
+  DuckDBPool,
+  discoverPackagesInRepo,
+  executeWithRecovery,
+  setupQueryContext,
+} from "@pietgk/devac-core";
+import type { Command } from "commander";
+import { formatOutput, formatTable } from "../output-formatter.js";
+
+interface SchemaTable {
+  name: string;
+  type: "seed" | "hub";
+  columns: Array<{
+    name: string;
+    type: string;
+  }>;
+}
+
+interface SchemaResult {
+  success: boolean;
+  tables: SchemaTable[];
+  skippedTables: string[];
+  output: string;
+  error?: string;
+}
+
+/**
+ * Find the repository root by looking for .git directory
+ */
+async function findRepoRoot(startPath: string): Promise<string | null> {
+  const fs = await import("node:fs/promises");
+  let currentPath = startPath;
+
+  while (currentPath !== path.dirname(currentPath)) {
+    try {
+      const gitPath = path.join(currentPath, ".git");
+      await fs.access(gitPath);
+      return currentPath;
+    } catch {
+      currentPath = path.dirname(currentPath);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get schema information
+ */
+async function getSchemaCommand(options: {
+  packagePath?: string;
+  json?: boolean;
+}): Promise<SchemaResult> {
+  let pool: DuckDBPool | null = null;
+
+  try {
+    pool = new DuckDBPool({ memoryLimit: "256MB" });
+    await pool.initialize();
+
+    const packagePath = options.packagePath || process.cwd();
+
+    // Discover packages for view setup
+    const repoRoot = await findRepoRoot(packagePath);
+    const packages = repoRoot
+      ? await discoverPackagesInRepo(repoRoot)
+      : await discoverPackagesInRepo(packagePath);
+
+    // Set up query context with views
+    const contextResult = await setupQueryContext(pool, {
+      packagePath,
+      packages: new Map(packages.map((p) => [p.name, p.path])),
+    });
+
+    // Get list of available views/tables
+    const tables: SchemaTable[] = [];
+    const skippedTables: string[] = [];
+
+    // Seed tables (always available)
+    const seedTables = ["nodes", "edges", "external_refs", "effects"];
+    for (const tableName of seedTables) {
+      if (contextResult.viewsCreated.includes(tableName)) {
+        try {
+          const columnsResult = await executeWithRecovery(pool, async (conn) => {
+            return await conn.all(`DESCRIBE ${tableName}`);
+          });
+
+          tables.push({
+            name: tableName,
+            type: "seed",
+            columns: (columnsResult as Array<{ column_name: string; column_type: string }>).map(
+              (col) => ({
+                name: col.column_name,
+                type: col.column_type,
+              })
+            ),
+          });
+        } catch (_error) {
+          // Table exists in views but failed to describe - track for reporting
+          skippedTables.push(tableName);
+        }
+      }
+    }
+
+    // Format output
+    let output: string;
+    if (options.json) {
+      output = formatOutput({ tables, skippedTables }, { json: true });
+    } else {
+      const lines = ["Available Tables:", ""];
+
+      for (const table of tables) {
+        lines.push(`${table.name} (${table.type}):`);
+
+        const rows = table.columns.map((col) => ({
+          Column: col.name,
+          Type: col.type,
+        }));
+
+        lines.push(formatTable(rows, { columns: ["Column", "Type"] }));
+        lines.push("");
+      }
+
+      if (tables.length === 0) {
+        lines.push("No tables found. Run 'devac sync' first to generate seeds.");
+      }
+
+      if (skippedTables.length > 0) {
+        lines.push(
+          `Note: ${skippedTables.length} table(s) could not be described: ${skippedTables.join(", ")}`
+        );
+      }
+
+      output = lines.join("\n");
+    }
+
+    return {
+      success: true,
+      tables,
+      skippedTables,
+      output,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      tables: [],
+      skippedTables: [],
+      output: options.json
+        ? formatOutput({ success: false, error: errorMessage }, { json: true })
+        : `Error: ${errorMessage}`,
+      error: errorMessage,
+    };
+  } finally {
+    if (pool) {
+      await pool.shutdown();
+    }
+  }
+}
+
+/**
+ * Register the schema subcommand under query
+ */
+export function registerQuerySchema(parent: Command): void {
+  parent
+    .command("schema")
+    .description("Get available tables and columns in the code graph database")
+    .option("-p, --package <path>", "Package path")
+    .option("--json", "Output as JSON")
+    .action(async (options) => {
+      const result = await getSchemaCommand({
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/sql.ts
+++ b/packages/devac-cli/src/commands/query/sql.ts
@@ -1,0 +1,66 @@
+/**
+ * Query SQL Subcommand
+ *
+ * Execute raw SQL queries against seed files.
+ * Supports @package syntax for multi-package queries.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { queryCommand } from "../query.js";
+import type { QueryOptions, QueryResult } from "../types.js";
+
+export interface QuerySqlOptions extends QueryOptions {}
+export interface QuerySqlResult extends QueryResult {}
+
+/**
+ * Register the sql subcommand under query
+ */
+export function registerQuerySql(parent: Command): void {
+  parent
+    .command("sql <sql>")
+    .description("Execute SQL query against seed files")
+    .option("-p, --package <path>", "Package path", process.cwd())
+    .option("-f, --format <type>", "Output format (json, csv, table)", "json")
+    .option("-l, --limit <n>", "Limit results")
+    .option("--json", "Output as JSON (shorthand for --format json)")
+    .action(async (sql, options) => {
+      const format = options.json ? "json" : options.format;
+
+      // Apply limit to SQL if specified
+      let processedSql = sql;
+      if (options.limit && !sql.toLowerCase().includes("limit")) {
+        processedSql = `${sql} LIMIT ${options.limit}`;
+      }
+
+      const result = await queryCommand({
+        sql: processedSql,
+        packagePath: path.resolve(options.package),
+        format,
+      });
+
+      if (result.success) {
+        switch (format) {
+          case "csv":
+            console.log(result.csv);
+            break;
+          case "table":
+            console.log(result.table);
+            break;
+          default: {
+            // BigInt values from DuckDB COUNT(*) need to be converted for JSON serialization
+            const bigIntReplacer = (_key: string, value: unknown) =>
+              typeof value === "bigint" ? Number(value) : value;
+            console.log(JSON.stringify(result.rows, bigIntReplacer, 2));
+          }
+        }
+
+        if (result.timeMs !== undefined) {
+          console.error(`\n(${result.rowCount} rows, ${result.timeMs}ms)`);
+        }
+      } else {
+        console.error(`✗ Query failed: ${result.error}`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/query/symbol.ts
+++ b/packages/devac-cli/src/commands/query/symbol.ts
@@ -1,0 +1,37 @@
+/**
+ * Query Symbol Subcommand
+ *
+ * Find symbols by name in the code graph.
+ * Wraps the find-symbol command functionality.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import { findSymbolCommand } from "../find-symbol.js";
+
+/**
+ * Register the symbol subcommand under query
+ */
+export function registerQuerySymbol(parent: Command): void {
+  parent
+    .command("symbol <name>")
+    .description("Find symbols by name")
+    .option("-p, --package <path>", "Query single package only")
+    .option("-k, --kind <kind>", "Filter by symbol kind (function, class, variable, etc.)")
+    .option("-l, --limit <count>", "Maximum results", "100")
+    .option("--json", "Output as JSON")
+    .action(async (name, options) => {
+      const result = await findSymbolCommand({
+        name,
+        kind: options.kind,
+        packagePath: options.package ? path.resolve(options.package) : undefined,
+        limit: options.limit ? Number.parseInt(options.limit, 10) : undefined,
+        json: options.json,
+      });
+
+      console.log(result.output);
+      if (!result.success) {
+        process.exit(1);
+      }
+    });
+}

--- a/packages/devac-cli/src/commands/sync.ts
+++ b/packages/devac-cli/src/commands/sync.ts
@@ -3,6 +3,7 @@
  *
  * Primary workflow for ensuring workspace seeds are analyzed and repos are registered.
  * Combines analyze + register in a single command with optimization by default.
+ * Enhanced with scope control, validation, watch mode, and GitHub data syncing.
  */
 
 import * as path from "node:path";
@@ -14,6 +15,16 @@ import {
 } from "@pietgk/devac-core";
 import type { Command } from "commander";
 import { analyzeCommand } from "./analyze.js";
+import { cleanCommand } from "./clean.js";
+import { contextCICommand, contextIssuesCommand } from "./context.js";
+import { docSyncCommand } from "./doc-sync.js";
+import { validateCommand } from "./validate.js";
+import { workspaceWatch } from "./workspace-watch.js";
+
+/**
+ * Scope level for sync command
+ */
+export type SyncScope = "workspace" | "repo" | "package" | "auto";
 
 /**
  * Sync command options
@@ -21,6 +32,8 @@ import { analyzeCommand } from "./analyze.js";
 export interface SyncOptions {
   /** Path to workspace or repository */
   path: string;
+  /** Scope level: workspace, repo, package, or auto (default: auto) */
+  scope?: SyncScope;
   /** Analyze packages needing analysis (default: true) */
   analyze?: boolean;
   /** Register repositories with hub (default: true) */
@@ -29,6 +42,18 @@ export interface SyncOptions {
   force?: boolean;
   /** Show what would be done without making changes (default: false) */
   dryRun?: boolean;
+  /** Run validation after analysis (default: false) */
+  validate?: boolean;
+  /** Clean stale data before syncing (default: false) */
+  clean?: boolean;
+  /** Sync CI status to hub (default: false) */
+  ci?: boolean;
+  /** Sync GitHub issues to hub (default: false) */
+  issues?: boolean;
+  /** Generate documentation (default: false) */
+  docs?: boolean;
+  /** Enable continuous watch mode (default: false) */
+  watch?: boolean;
   /** Callback for progress updates */
   onProgress?: (message: string) => void;
 }
@@ -45,10 +70,38 @@ export interface SyncResult {
   packagesSkipped: number;
   /** Number of repositories registered */
   reposRegistered: number;
+  /** Number of packages cleaned */
+  packagesCleaned: number;
+  /** Whether validation passed */
+  validationPassed?: boolean;
+  /** Number of CI checks synced */
+  ciChecksSynced: number;
+  /** Number of issues synced */
+  issuesSynced: number;
+  /** Number of docs generated */
+  docsGenerated: number;
   /** List of errors encountered */
   errors: string[];
   /** User-facing message */
   message: string;
+}
+
+/**
+ * Create an error result helper
+ */
+function createErrorResult(errors: string[], message: string): SyncResult {
+  return {
+    success: false,
+    packagesAnalyzed: 0,
+    packagesSkipped: 0,
+    reposRegistered: 0,
+    packagesCleaned: 0,
+    ciChecksSynced: 0,
+    issuesSynced: 0,
+    docsGenerated: 0,
+    errors,
+    message,
+  };
 }
 
 /**
@@ -57,10 +110,17 @@ export interface SyncResult {
 export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
   const {
     path: inputPath,
+    scope: _scope = "auto",
     analyze = true,
     register = true,
     force = false,
     dryRun = false,
+    validate = false,
+    clean = false,
+    ci = false,
+    issues = false,
+    docs = false,
+    watch = false,
     onProgress,
   } = options;
 
@@ -68,18 +128,19 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
   let packagesAnalyzed = 0;
   let packagesSkipped = 0;
   let reposRegistered = 0;
+  let packagesCleaned = 0;
+  let validationPassed: boolean | undefined;
+  let ciChecksSynced = 0;
+  let issuesSynced = 0;
+  let docsGenerated = 0;
 
   // Step 1: Find workspace
   const workspaceDir = await findWorkspaceDir(inputPath);
   if (!workspaceDir) {
-    return {
-      success: false,
-      packagesAnalyzed: 0,
-      packagesSkipped: 0,
-      reposRegistered: 0,
-      errors: [`Not in a workspace: ${inputPath}`],
-      message: "Not in a workspace. Run from a workspace directory.",
-    };
+    return createErrorResult(
+      [`Not in a workspace: ${inputPath}`],
+      "Not in a workspace. Run from a workspace directory."
+    );
   }
 
   // Step 2: Check hub is initialized
@@ -90,14 +151,10 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
     // This will throw if hub is not initialized
     await client.getStatus();
   } catch {
-    return {
-      success: false,
-      packagesAnalyzed: 0,
-      packagesSkipped: 0,
-      reposRegistered: 0,
-      errors: ["Hub not initialized"],
-      message: "Hub not initialized. Run 'devac hub init' first.",
-    };
+    return createErrorResult(
+      ["Hub not initialized"],
+      "Hub not initialized. Run 'devac hub init' first."
+    );
   }
 
   // Step 3: Get workspace status
@@ -105,14 +162,10 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
   try {
     status = await getWorkspaceStatus({ path: workspaceDir });
   } catch (error) {
-    return {
-      success: false,
-      packagesAnalyzed: 0,
-      packagesSkipped: 0,
-      reposRegistered: 0,
-      errors: [error instanceof Error ? error.message : String(error)],
-      message: "Failed to get workspace status",
-    };
+    return createErrorResult(
+      [error instanceof Error ? error.message : String(error)],
+      "Failed to get workspace status"
+    );
   }
 
   // Step 4: Dry run - report what would be done
@@ -123,13 +176,37 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
     ).length;
 
     onProgress?.("Dry run - would perform the following:");
+    if (clean) {
+      onProgress?.("  - Clean stale seeds");
+    }
     if (analyze && packagesNeedingAnalysis > 0) {
       onProgress?.(`  - Analyze ${packagesNeedingAnalysis} package(s)`);
     }
     if (register && reposNeedingRegistration > 0) {
       onProgress?.(`  - Register ${reposNeedingRegistration} repository(ies)`);
     }
-    if (packagesNeedingAnalysis === 0 && reposNeedingRegistration === 0) {
+    if (validate) {
+      onProgress?.("  - Run validation after analysis");
+    }
+    if (ci) {
+      onProgress?.("  - Sync CI status to hub");
+    }
+    if (issues) {
+      onProgress?.("  - Sync GitHub issues to hub");
+    }
+    if (docs) {
+      onProgress?.("  - Generate documentation");
+    }
+    if (watch) {
+      onProgress?.("  - Enable continuous watch mode");
+    }
+    if (
+      packagesNeedingAnalysis === 0 &&
+      reposNeedingRegistration === 0 &&
+      !ci &&
+      !issues &&
+      !docs
+    ) {
       onProgress?.("  - Nothing to do, workspace is up-to-date");
     }
 
@@ -138,12 +215,38 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
       packagesAnalyzed: 0,
       packagesSkipped: 0,
       reposRegistered: 0,
+      packagesCleaned: 0,
+      ciChecksSynced: 0,
+      issuesSynced: 0,
+      docsGenerated: 0,
       errors: [],
       message: `Dry run: would analyze ${packagesNeedingAnalysis} package(s), register ${reposNeedingRegistration} repo(s)`,
     };
   }
 
-  // Step 5: Analyze packages if enabled
+  // Step 5: Clean stale data if requested
+  if (clean) {
+    onProgress?.("Cleaning stale data...");
+    for (const repo of status.repos) {
+      if (!repo.seedStatus) continue;
+
+      for (const pkg of repo.seedStatus.packages) {
+        try {
+          const cleanResult = await cleanCommand({ packagePath: pkg.packagePath });
+          if (cleanResult.success && cleanResult.filesRemoved > 0) {
+            packagesCleaned++;
+            onProgress?.(`  ✓ Cleaned ${pkg.packageName}: ${cleanResult.filesRemoved} files`);
+          }
+        } catch (err) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          errors.push(`Clean ${pkg.packageName}: ${errorMsg}`);
+          onProgress?.(`  ✗ ${pkg.packageName}: ${errorMsg}`);
+        }
+      }
+    }
+  }
+
+  // Step 6: Analyze packages if enabled
   if (analyze) {
     for (const repo of status.repos) {
       if (!repo.seedStatus) continue;
@@ -151,12 +254,12 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
       // Find packages needing analysis
       const packagesNeedingWork = repo.seedStatus.packages.filter((pkg) => !pkg.hasBase);
 
-      if (packagesNeedingWork.length === 0 && !force) {
+      if (packagesNeedingWork.length === 0 && !force && !clean) {
         continue;
       }
 
       // Analyze each package
-      const packagesToAnalyze = force ? repo.seedStatus.packages : packagesNeedingWork;
+      const packagesToAnalyze = force || clean ? repo.seedStatus.packages : packagesNeedingWork;
 
       for (const pkg of packagesToAnalyze) {
         onProgress?.(`Analyzing ${pkg.packageName}...`);
@@ -166,8 +269,8 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
             packagePath: pkg.packagePath,
             repoName: repo.name,
             branch: "base",
-            ifChanged: !force,
-            force: force,
+            ifChanged: !force && !clean,
+            force: force || clean,
           });
 
           if (result.success) {
@@ -193,11 +296,11 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
     }
   }
 
-  // Step 6: Register repos if enabled
+  // Step 7: Register repos if enabled
   if (register) {
     for (const repo of status.repos) {
       // Skip if already registered and we didn't analyze anything new
-      if (repo.hubStatus === "registered" && packagesAnalyzed === 0 && !force) {
+      if (repo.hubStatus === "registered" && packagesAnalyzed === 0 && !force && !clean) {
         continue;
       }
 
@@ -217,8 +320,143 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
     }
   }
 
+  // Step 8: Run validation if requested
+  if (validate && packagesAnalyzed > 0) {
+    onProgress?.("Running validation...");
+    let allPassed = true;
+
+    for (const repo of status.repos) {
+      if (!repo.seedStatus) continue;
+
+      for (const pkg of repo.seedStatus.packages) {
+        try {
+          const validateResult = await validateCommand({
+            packagePath: pkg.packagePath,
+            changedFiles: [],
+            mode: "quick",
+          });
+
+          if (!validateResult.success || validateResult.totalIssues > 0) {
+            allPassed = false;
+            onProgress?.(`  ⚠ ${pkg.packageName}: ${validateResult.totalIssues} issue(s)`);
+          } else {
+            onProgress?.(`  ✓ ${pkg.packageName}: validation passed`);
+          }
+        } catch (err) {
+          allPassed = false;
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          errors.push(`Validate ${pkg.packageName}: ${errorMsg}`);
+          onProgress?.(`  ✗ ${pkg.packageName}: ${errorMsg}`);
+        }
+      }
+    }
+    validationPassed = allPassed;
+  }
+
+  // Step 9: Sync CI status if requested
+  if (ci) {
+    onProgress?.("Syncing CI status...");
+    try {
+      const ciResult = await contextCICommand({
+        cwd: workspaceDir,
+        syncToHub: true,
+        failingOnly: false,
+      });
+
+      if (ciResult.success && ciResult.syncResult) {
+        ciChecksSynced = ciResult.syncResult.pushed;
+        onProgress?.(`  ✓ Synced ${ciChecksSynced} CI check(s) to hub`);
+      } else if (!ciResult.success) {
+        errors.push(`CI sync: ${ciResult.error || "Failed"}`);
+        onProgress?.(`  ✗ CI sync failed: ${ciResult.error || "Unknown error"}`);
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      errors.push(`CI sync: ${errorMsg}`);
+      onProgress?.(`  ✗ CI sync: ${errorMsg}`);
+    }
+  }
+
+  // Step 10: Sync GitHub issues if requested
+  if (issues) {
+    onProgress?.("Syncing GitHub issues...");
+    try {
+      const issuesResult = await contextIssuesCommand({
+        cwd: workspaceDir,
+        syncToHub: true,
+        openOnly: true,
+      });
+
+      if (issuesResult.success && issuesResult.syncResult) {
+        issuesSynced = issuesResult.syncResult.pushed;
+        onProgress?.(`  ✓ Synced ${issuesSynced} issue(s) to hub`);
+      } else if (!issuesResult.success) {
+        errors.push(`Issues sync: ${issuesResult.error || "Failed"}`);
+        onProgress?.(`  ✗ Issues sync failed: ${issuesResult.error || "Unknown error"}`);
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      errors.push(`Issues sync: ${errorMsg}`);
+      onProgress?.(`  ✗ Issues sync: ${errorMsg}`);
+    }
+  }
+
+  // Step 11: Generate documentation if requested
+  if (docs) {
+    onProgress?.("Generating documentation...");
+    try {
+      const docResult = await docSyncCommand({
+        workspace: true,
+        all: true,
+        force: force,
+      });
+
+      if (docResult.success) {
+        docsGenerated = docResult.packagesProcessed;
+        onProgress?.(`  ✓ Generated docs for ${docsGenerated} package(s)`);
+      } else {
+        // Collect errors from individual package results
+        const docErrors = docResult.packages.flatMap((pkg) => pkg.errors);
+        const errorMsg = docErrors.length > 0 ? docErrors.join("; ") : "Generation failed";
+        errors.push(`Docs: ${errorMsg}`);
+        onProgress?.(`  ✗ Doc generation failed: ${errorMsg}`);
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      errors.push(`Docs: ${errorMsg}`);
+      onProgress?.(`  ✗ Docs: ${errorMsg}`);
+    }
+  }
+
+  // Step 12: Start watch mode if requested
+  if (watch) {
+    onProgress?.("Starting watch mode...");
+    try {
+      const watchResult = await workspaceWatch({
+        workspacePath: workspaceDir,
+        autoRefresh: true,
+      });
+
+      if (watchResult.success && watchResult.controller) {
+        onProgress?.("  ✓ Watch mode started. Press Ctrl+C to stop.");
+        // In watch mode, we don't return - the watch continues
+        // The caller should handle the watch controller
+      } else {
+        errors.push(`Watch: ${watchResult.error || "Failed to start"}`);
+        onProgress?.(`  ✗ Watch mode failed: ${watchResult.error || "Unknown error"}`);
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      errors.push(`Watch: ${errorMsg}`);
+      onProgress?.(`  ✗ Watch: ${errorMsg}`);
+    }
+  }
+
   // Build summary message
   const parts: string[] = [];
+  if (packagesCleaned > 0) {
+    parts.push(`${packagesCleaned} cleaned`);
+  }
   if (packagesAnalyzed > 0) {
     parts.push(`${packagesAnalyzed} package(s) analyzed`);
   }
@@ -227,6 +465,18 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
   }
   if (reposRegistered > 0) {
     parts.push(`${reposRegistered} repo(s) registered`);
+  }
+  if (validationPassed !== undefined) {
+    parts.push(validationPassed ? "validation passed" : "validation failed");
+  }
+  if (ciChecksSynced > 0) {
+    parts.push(`${ciChecksSynced} CI check(s) synced`);
+  }
+  if (issuesSynced > 0) {
+    parts.push(`${issuesSynced} issue(s) synced`);
+  }
+  if (docsGenerated > 0) {
+    parts.push(`${docsGenerated} doc(s) generated`);
   }
   if (errors.length > 0) {
     parts.push(`${errors.length} error(s)`);
@@ -240,6 +490,11 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
     packagesAnalyzed,
     packagesSkipped,
     reposRegistered,
+    packagesCleaned,
+    validationPassed,
+    ciChecksSynced,
+    issuesSynced,
+    docsGenerated,
     errors,
     message,
   };
@@ -253,17 +508,31 @@ export function registerSyncCommand(program: Command): void {
     .command("sync")
     .description("Analyze packages and register repos with hub")
     .option("-p, --path <path>", "Workspace path", process.cwd())
+    .option("--scope <level>", "Scope level: workspace, repo, package, auto", "auto")
     .option("--analyze-only", "Only analyze, don't register")
     .option("--register-only", "Only register, don't analyze")
     .option("--force", "Force full reanalysis (ignore --if-changed optimization)")
     .option("--dry-run", "Show what would be done without making changes")
+    .option("--validate", "Run validation after analysis")
+    .option("--clean", "Clean stale data before syncing")
+    .option("--ci", "Sync CI status to hub")
+    .option("--issues", "Sync GitHub issues to hub")
+    .option("--docs", "Generate documentation")
+    .option("--watch", "Enable continuous watch mode")
     .action(async (opts) => {
       const result = await syncCommand({
         path: opts.path,
+        scope: opts.scope as SyncScope,
         analyze: !opts.registerOnly,
         register: !opts.analyzeOnly,
         force: opts.force ?? false,
         dryRun: opts.dryRun ?? false,
+        validate: opts.validate ?? false,
+        clean: opts.clean ?? false,
+        ci: opts.ci ?? false,
+        issues: opts.issues ?? false,
+        docs: opts.docs ?? false,
+        watch: opts.watch ?? false,
         onProgress: (msg) => console.log(msg),
       });
 

--- a/packages/devac-cli/src/index.ts
+++ b/packages/devac-cli/src/index.ts
@@ -10,36 +10,11 @@
 import { setGlobalLogLevel } from "@pietgk/devac-core";
 import { Command } from "commander";
 import {
-  registerAffectedCommand,
-  registerAnalyzeCommand,
-  registerArchitectureCommand,
-  registerC4Command,
-  registerCallGraphCommand,
-  registerCleanCommand,
-  registerContextCommand,
-  registerCoverageCommand,
-  registerDependentsCommand,
-  registerDepsCommand,
-  registerDiagnosticsCommand,
-  registerDocSyncCommand,
-  registerDoctorCommand,
-  registerEffectsCommand,
-  registerFileSymbolsCommand,
-  registerFindSymbolCommand,
-  registerHubCommand,
-  registerLintCommand,
   registerMcpCommand,
   registerQueryCommand,
-  registerRulesCommand,
   registerStatusCommand,
   registerSyncCommand,
-  registerTestCommand,
-  registerTypecheckCommand,
-  registerValidateCommand,
-  registerVerifyCommand,
-  registerWatchCommand,
   registerWorkflowCommand,
-  registerWorkspaceCommand,
 } from "./commands/index.js";
 import { VERSION } from "./version.js";
 
@@ -60,49 +35,28 @@ program
     }
   });
 
-// Register all commands
-registerStatusCommand(program);
-registerAnalyzeCommand(program);
-registerQueryCommand(program);
-registerVerifyCommand(program);
-registerCleanCommand(program);
-registerWatchCommand(program);
-registerTypecheckCommand(program);
-registerLintCommand(program);
-registerTestCommand(program);
-registerCoverageCommand(program);
-registerValidateCommand(program);
-registerAffectedCommand(program);
-registerFindSymbolCommand(program);
-registerDepsCommand(program);
-registerDependentsCommand(program);
-registerFileSymbolsCommand(program);
-registerCallGraphCommand(program);
-registerContextCommand(program);
-registerMcpCommand(program);
-registerHubCommand(program);
-registerWorkspaceCommand(program);
-registerDiagnosticsCommand(program);
+// ─────────────────────────────────────────────────────────────────────────────
+// Three Core Commands (v4.0 reorganization)
+// ─────────────────────────────────────────────────────────────────────────────
 
-// v3.0 Effects, Rules, C4 commands
-registerEffectsCommand(program);
-registerRulesCommand(program);
-registerC4Command(program);
-
-// Architecture commands (improvement loop)
-registerArchitectureCommand(program);
-
-// Workflow commands (deterministic development operations)
-registerWorkflowCommand(program);
-
-// Doctor command (system health checks)
-registerDoctorCommand(program);
-
-// Sync command (analyze + register workflow)
+// Sync: analyze packages, register repos, sync CI/issues/docs
 registerSyncCommand(program);
 
-// Doc-sync command (documentation generation)
-registerDocSyncCommand(program);
+// Status: workspace health, seeds, diagnostics, doctor
+registerStatusCommand(program);
+
+// Query: all code graph queries (symbol, deps, sql, etc.)
+registerQueryCommand(program);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Utility Commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+// MCP: start MCP server for AI assistants
+registerMcpCommand(program);
+
+// Workflow: CI/git integration (pre-commit, prepare-ship, etc.)
+registerWorkflowCommand(program);
 
 // Default action: show status one-liner when no command is provided
 program.action(async () => {

--- a/packages/devac-mcp/__tests__/server.test.ts
+++ b/packages/devac-mcp/__tests__/server.test.ts
@@ -243,14 +243,18 @@ describe("MCP Tool Registration", () => {
   it("has all expected tools defined", () => {
     const toolNames = MCP_TOOLS.map((t) => t.name);
 
-    expect(toolNames).toContain("find_symbol");
-    expect(toolNames).toContain("get_dependencies");
-    expect(toolNames).toContain("get_dependents");
-    expect(toolNames).toContain("get_file_symbols");
-    expect(toolNames).toContain("get_affected");
-    expect(toolNames).toContain("get_call_graph");
+    // Query tools
+    expect(toolNames).toContain("query_symbol");
+    expect(toolNames).toContain("query_deps");
+    expect(toolNames).toContain("query_dependents");
+    expect(toolNames).toContain("query_file");
+    expect(toolNames).toContain("query_affected");
+    expect(toolNames).toContain("query_call_graph");
     expect(toolNames).toContain("query_sql");
-    expect(toolNames).toContain("list_repos");
+    expect(toolNames).toContain("query_repos");
+    // Status tools
+    expect(toolNames).toContain("status");
+    expect(toolNames).toContain("status_diagnostics");
   });
 
   it("each tool has required properties", () => {
@@ -263,34 +267,34 @@ describe("MCP Tool Registration", () => {
     }
   });
 
-  it("find_symbol requires name parameter", () => {
-    const findSymbol = MCP_TOOLS.find((t) => t.name === "find_symbol");
-    expect(findSymbol?.inputSchema.required).toContain("name");
+  it("query_symbol requires name parameter", () => {
+    const querySymbol = MCP_TOOLS.find((t) => t.name === "query_symbol");
+    expect(querySymbol?.inputSchema.required).toContain("name");
   });
 
-  it("get_dependencies requires entityId parameter", () => {
-    const getDeps = MCP_TOOLS.find((t) => t.name === "get_dependencies");
-    expect(getDeps?.inputSchema.required).toContain("entityId");
+  it("query_deps requires entityId parameter", () => {
+    const queryDeps = MCP_TOOLS.find((t) => t.name === "query_deps");
+    expect(queryDeps?.inputSchema.required).toContain("entityId");
   });
 
-  it("get_dependents requires entityId parameter", () => {
-    const getDependents = MCP_TOOLS.find((t) => t.name === "get_dependents");
-    expect(getDependents?.inputSchema.required).toContain("entityId");
+  it("query_dependents requires entityId parameter", () => {
+    const queryDependents = MCP_TOOLS.find((t) => t.name === "query_dependents");
+    expect(queryDependents?.inputSchema.required).toContain("entityId");
   });
 
-  it("get_file_symbols requires filePath parameter", () => {
-    const getFileSymbols = MCP_TOOLS.find((t) => t.name === "get_file_symbols");
-    expect(getFileSymbols?.inputSchema.required).toContain("filePath");
+  it("query_file requires filePath parameter", () => {
+    const queryFile = MCP_TOOLS.find((t) => t.name === "query_file");
+    expect(queryFile?.inputSchema.required).toContain("filePath");
   });
 
-  it("get_affected requires changedFiles parameter", () => {
-    const getAffected = MCP_TOOLS.find((t) => t.name === "get_affected");
-    expect(getAffected?.inputSchema.required).toContain("changedFiles");
+  it("query_affected requires changedFiles parameter", () => {
+    const queryAffected = MCP_TOOLS.find((t) => t.name === "query_affected");
+    expect(queryAffected?.inputSchema.required).toContain("changedFiles");
   });
 
-  it("get_call_graph requires entityId parameter", () => {
-    const getCallGraph = MCP_TOOLS.find((t) => t.name === "get_call_graph");
-    expect(getCallGraph?.inputSchema.required).toContain("entityId");
+  it("query_call_graph requires entityId parameter", () => {
+    const queryCallGraph = MCP_TOOLS.find((t) => t.name === "query_call_graph");
+    expect(queryCallGraph?.inputSchema.required).toContain("entityId");
   });
 
   it("query_sql requires sql parameter", () => {
@@ -298,9 +302,9 @@ describe("MCP Tool Registration", () => {
     expect(querySql?.inputSchema.required).toContain("sql");
   });
 
-  it("get_call_graph has direction enum", () => {
-    const getCallGraph = MCP_TOOLS.find((t) => t.name === "get_call_graph");
-    const directionProp = getCallGraph?.inputSchema.properties.direction as {
+  it("query_call_graph has direction enum", () => {
+    const queryCallGraph = MCP_TOOLS.find((t) => t.name === "query_call_graph");
+    const directionProp = queryCallGraph?.inputSchema.properties.direction as {
       enum?: string[];
     };
     expect(directionProp?.enum).toEqual(["callers", "callees", "both"]);

--- a/packages/devac-mcp/__tests__/tools.test.ts
+++ b/packages/devac-mcp/__tests__/tools.test.ts
@@ -20,20 +20,24 @@ describe("MCP Tool Definitions", () => {
     it("contains expected tool names", () => {
       const toolNames = MCP_TOOLS.map((t) => t.name);
 
-      expect(toolNames).toContain("find_symbol");
-      expect(toolNames).toContain("get_dependencies");
-      expect(toolNames).toContain("get_dependents");
-      expect(toolNames).toContain("get_file_symbols");
-      expect(toolNames).toContain("get_affected");
-      expect(toolNames).toContain("get_call_graph");
+      // Query tools
+      expect(toolNames).toContain("query_symbol");
+      expect(toolNames).toContain("query_deps");
+      expect(toolNames).toContain("query_dependents");
+      expect(toolNames).toContain("query_file");
+      expect(toolNames).toContain("query_affected");
+      expect(toolNames).toContain("query_call_graph");
       expect(toolNames).toContain("query_sql");
-      expect(toolNames).toContain("get_schema");
-      expect(toolNames).toContain("list_repos");
-      expect(toolNames).toContain("get_context");
+      expect(toolNames).toContain("query_schema");
+      expect(toolNames).toContain("query_repos");
+      expect(toolNames).toContain("query_context");
+      // Status tools
+      expect(toolNames).toContain("status");
+      expect(toolNames).toContain("status_diagnostics");
       // Unified diagnostics tools
-      expect(toolNames).toContain("get_all_diagnostics");
-      expect(toolNames).toContain("get_diagnostics_summary");
-      expect(toolNames).toContain("get_diagnostics_counts");
+      expect(toolNames).toContain("status_all_diagnostics");
+      expect(toolNames).toContain("status_all_diagnostics_summary");
+      expect(toolNames).toContain("status_all_diagnostics_counts");
     });
 
     it("has exactly 21 tools", () => {
@@ -64,8 +68,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("find_symbol schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "find_symbol");
+  describe("query_symbol schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_symbol");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -92,8 +96,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("get_dependencies schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "get_dependencies");
+  describe("query_deps schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_deps");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -110,8 +114,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("get_dependents schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "get_dependents");
+  describe("query_dependents schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_dependents");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -128,8 +132,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("get_file_symbols schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "get_file_symbols");
+  describe("query_file schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_file");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -146,8 +150,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("get_affected schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "get_affected");
+  describe("query_affected schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_affected");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -169,8 +173,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("get_call_graph schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "get_call_graph");
+  describe("query_call_graph schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_call_graph");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -214,8 +218,8 @@ describe("MCP Tool Definitions", () => {
     });
   });
 
-  describe("list_repos schema", () => {
-    const tool = MCP_TOOLS.find((t) => t.name === "list_repos");
+  describe("query_repos schema", () => {
+    const tool = MCP_TOOLS.find((t) => t.name === "query_repos");
 
     it("exists", () => {
       expect(tool).toBeDefined();
@@ -232,9 +236,9 @@ describe("MCP Tool Definitions", () => {
 });
 
 describe("Tool Input Validation", () => {
-  describe("find_symbol", () => {
+  describe("query_symbol", () => {
     it("schema accepts valid input", () => {
-      const tool = MCP_TOOLS.find((t) => t.name === "find_symbol");
+      const tool = MCP_TOOLS.find((t) => t.name === "query_symbol");
       const validInput = { name: "Calculator" };
 
       // Schema validation - properties exist
@@ -243,7 +247,7 @@ describe("Tool Input Validation", () => {
     });
 
     it("schema accepts optional kind", () => {
-      const tool = MCP_TOOLS.find((t) => t.name === "find_symbol");
+      const tool = MCP_TOOLS.find((t) => t.name === "query_symbol");
       const validInput = { name: "Calculator", kind: "class" };
 
       expect(tool?.inputSchema.properties.kind).toBeDefined();
@@ -251,9 +255,9 @@ describe("Tool Input Validation", () => {
     });
   });
 
-  describe("get_affected", () => {
+  describe("query_affected", () => {
     it("schema accepts array of changed files", () => {
-      const tool = MCP_TOOLS.find((t) => t.name === "get_affected");
+      const tool = MCP_TOOLS.find((t) => t.name === "query_affected");
       const validInput = { changedFiles: ["src/a.ts", "src/b.ts"] };
 
       expect((tool?.inputSchema.properties.changedFiles as { type: string }).type).toBe("array");
@@ -261,7 +265,7 @@ describe("Tool Input Validation", () => {
     });
 
     it("schema accepts optional maxDepth", () => {
-      const tool = MCP_TOOLS.find((t) => t.name === "get_affected");
+      const tool = MCP_TOOLS.find((t) => t.name === "query_affected");
       const validInput = { changedFiles: ["src/a.ts"], maxDepth: 5 };
 
       expect((tool?.inputSchema.properties.maxDepth as { type: string }).type).toBe("number");
@@ -269,9 +273,9 @@ describe("Tool Input Validation", () => {
     });
   });
 
-  describe("get_call_graph", () => {
+  describe("query_call_graph", () => {
     it("schema accepts direction values", () => {
-      const tool = MCP_TOOLS.find((t) => t.name === "get_call_graph");
+      const tool = MCP_TOOLS.find((t) => t.name === "query_call_graph");
       const directions = ["callers", "callees", "both"];
 
       expect(tool?.inputSchema.properties.direction).toBeDefined();
@@ -294,7 +298,7 @@ describe("Tool Input Validation", () => {
 
 describe("Tool Error Scenarios", () => {
   describe("SQL injection prevention", () => {
-    it("find_symbol escapes single quotes in name", () => {
+    it("query_symbol escapes single quotes in name", () => {
       // This tests the escaping pattern used in the server
       // Single quotes are escaped by doubling them in SQL
       const maliciousName = "'; DROP TABLE nodes; --";
@@ -306,7 +310,7 @@ describe("Tool Error Scenarios", () => {
       // because it's now a literal string containing two quotes
     });
 
-    it("get_file_symbols escapes single quotes in filePath", () => {
+    it("query_file escapes single quotes in filePath", () => {
       const maliciousPath = "'; DELETE FROM nodes; --";
       const escaped = maliciousPath.replace(/'/g, "''");
 

--- a/packages/devac-mcp/src/server.ts
+++ b/packages/devac-mcp/src/server.ts
@@ -126,8 +126,8 @@ export class DevacMCPServer {
     toolName: string,
     input: Record<string, unknown>
   ): Promise<MCPToolResult> {
-    // get_context doesn't require the data provider
-    if (toolName === "get_context") {
+    // query_context doesn't require the data provider
+    if (toolName === "query_context") {
       return await this.executeGetContext(input);
     }
 
@@ -137,69 +137,71 @@ export class DevacMCPServer {
 
     try {
       switch (toolName) {
-        case "find_symbol":
+        // Query tools
+        case "query_symbol":
           return await this.executeFindSymbol(input);
 
-        case "get_dependencies":
+        case "query_deps":
           return await this.executeGetDependencies(input);
 
-        case "get_dependents":
+        case "query_dependents":
           return await this.executeGetDependents(input);
 
-        case "get_file_symbols":
+        case "query_file":
           return await this.executeGetFileSymbols(input);
 
-        case "get_affected":
+        case "query_affected":
           return await this.executeGetAffected(input);
 
-        case "get_call_graph":
+        case "query_call_graph":
           return await this.executeGetCallGraph(input);
 
         case "query_sql":
           return await this.executeQuerySql(input);
 
-        case "get_schema":
+        case "query_schema":
           return await this.executeGetSchema();
 
-        case "list_repos":
+        case "query_repos":
           return await this.executeListRepos();
 
-        case "get_context":
+        case "query_context":
           return await this.executeGetContext(input);
 
-        case "get_workspace_status":
+        // Status tools
+        case "status":
           return await this.executeGetWorkspaceStatus(input);
 
-        case "get_validation_errors":
+        case "status_diagnostics":
           return await this.executeGetValidationErrors(input);
 
-        case "get_validation_summary":
+        case "status_diagnostics_summary":
           return await this.executeGetValidationSummary(input);
 
-        case "get_validation_counts":
+        case "status_diagnostics_counts":
           return await this.executeGetValidationCounts();
 
         // Unified Diagnostics tools
-        case "get_all_diagnostics":
+        case "status_all_diagnostics":
           return await this.executeGetAllDiagnostics(input);
 
-        case "get_diagnostics_summary":
+        case "status_all_diagnostics_summary":
           return await this.executeGetDiagnosticsSummary(input);
 
-        case "get_diagnostics_counts":
+        case "status_all_diagnostics_counts":
           return await this.executeGetDiagnosticsCounts();
 
-        // Effects, Rules, C4 tools (v3.0)
+        // Query: Effects, Rules, C4 tools (v3.0)
         case "query_effects":
           return await this.executeQueryEffects(input);
 
-        case "run_rules":
+        case "query_rules":
           return await this.executeRunRules(input);
 
-        case "list_rules":
+        case "query_rules_list":
           return await this.executeListRules(input);
 
-        case "generate_c4":
+        case "query_c4":
           return await this.executeGenerateC4(input);
 
         default:

--- a/packages/devac-mcp/src/tools/index.ts
+++ b/packages/devac-mcp/src/tools/index.ts
@@ -1,5 +1,9 @@
 /**
  * MCP Tool Definitions
+ *
+ * Tool naming follows the CLI command pattern:
+ * - query_* for querying the code graph
+ * - status_* for status/diagnostics
  */
 
 import type { MCPTool } from "../types.js";
@@ -8,8 +12,9 @@ import type { MCPTool } from "../types.js";
  * All available MCP tools
  */
 export const MCP_TOOLS: MCPTool[] = [
+  // ================== Query Tools ==================
   {
-    name: "find_symbol",
+    name: "query_symbol",
     description: "Find a symbol by name in the codebase",
     inputSchema: {
       type: "object",
@@ -21,7 +26,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_dependencies",
+    name: "query_deps",
     description: "Get dependencies of a symbol",
     inputSchema: {
       type: "object",
@@ -33,7 +38,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_dependents",
+    name: "query_dependents",
     description: "Get symbols that depend on the target",
     inputSchema: {
       type: "object",
@@ -45,7 +50,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_file_symbols",
+    name: "query_file",
     description: "Get all symbols defined in a file",
     inputSchema: {
       type: "object",
@@ -56,7 +61,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_affected",
+    name: "query_affected",
     description: "Get files affected by changes",
     inputSchema: {
       type: "object",
@@ -72,7 +77,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_call_graph",
+    name: "query_call_graph",
     description: "Get the call graph for a function",
     inputSchema: {
       type: "object",
@@ -101,7 +106,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_schema",
+    name: "query_schema",
     description:
       "Get available tables and columns in the code graph database. Useful for discovering the schema before writing SQL queries. Returns seed tables (nodes, edges, external_refs, effects) and hub tables (repo_registry, validation_errors, unified_diagnostics).",
     inputSchema: {
@@ -111,7 +116,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "list_repos",
+    name: "query_repos",
     description:
       "List all registered repositories in the hub. Only available in hub mode. Returns repository metadata including path, package count, status, and last sync time.",
     inputSchema: {
@@ -121,7 +126,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_context",
+    name: "query_context",
     description:
       "Discover the current working context including sibling repositories and issue worktrees. Returns information about the current directory, parent directory containing repos, and any issue-related worktrees.",
     inputSchema: {
@@ -143,8 +148,9 @@ export const MCP_TOOLS: MCPTool[] = [
       required: [],
     },
   },
+  // ================== Status Tools ==================
   {
-    name: "get_workspace_status",
+    name: "status",
     description:
       "Get workspace status including seed states for all repositories and packages. Shows which packages are analyzed (have base seeds), need analysis, or have delta changes. Use this to understand what needs to be analyzed or registered with the hub.",
     inputSchema: {
@@ -163,7 +169,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_validation_errors",
+    name: "status_diagnostics",
     description:
       "Get validation errors (type errors, lint issues, test failures) from the hub cache. Returns errors that need to be fixed. Only available in hub mode.",
     inputSchema: {
@@ -196,7 +202,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_validation_summary",
+    name: "status_diagnostics_summary",
     description:
       "Get a summary of validation errors grouped by repository, file, source, or severity. Useful for getting an overview of issues. Only available in hub mode.",
     inputSchema: {
@@ -212,7 +218,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_validation_counts",
+    name: "status_diagnostics_counts",
     description:
       "Get total counts of validation errors and warnings across all repositories. Only available in hub mode.",
     inputSchema: {
@@ -223,7 +229,7 @@ export const MCP_TOOLS: MCPTool[] = [
   },
   // ================== Unified Diagnostics Tools ==================
   {
-    name: "get_all_diagnostics",
+    name: "status_all_diagnostics",
     description:
       "Get all diagnostics (validation errors, CI failures, GitHub issues, PR reviews) from a unified view. Filter by source, severity, category, and more. Use this to answer 'What do I need to fix?' across all diagnostics types. Only available in hub mode.",
     inputSchema: {
@@ -288,7 +294,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_diagnostics_summary",
+    name: "status_all_diagnostics_summary",
     description:
       "Get a summary of all diagnostics grouped by source, severity, category, or repository. Provides an overview of what needs attention. Only available in hub mode.",
     inputSchema: {
@@ -304,7 +310,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "get_diagnostics_counts",
+    name: "status_all_diagnostics_counts",
     description:
       "Get total counts of diagnostics by severity (critical, error, warning, suggestion, note). Only available in hub mode.",
     inputSchema: {
@@ -313,7 +319,7 @@ export const MCP_TOOLS: MCPTool[] = [
       required: [],
     },
   },
-  // ================== Effects, Rules, C4 Tools (v3.0) ==================
+  // ================== Query Effects, Rules, C4 Tools (v3.0) ==================
   {
     name: "query_effects",
     description:
@@ -351,7 +357,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "run_rules",
+    name: "query_rules",
     description:
       "Run the rules engine on effects to produce domain effects. Domain effects are high-level classifications like 'Payment:Charge', 'Auth:TokenVerify', 'Database:Query'. Returns matched domain effects and statistics about rule matches.",
     inputSchema: {
@@ -374,7 +380,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "list_rules",
+    name: "query_rules_list",
     description:
       "List available rules in the rules engine. Rules define patterns for classifying code effects into domain effects.",
     inputSchema: {
@@ -393,7 +399,7 @@ export const MCP_TOOLS: MCPTool[] = [
     },
   },
   {
-    name: "generate_c4",
+    name: "query_c4",
     description:
       "Generate C4 architecture diagrams from code effects. Returns C4 model data and optionally PlantUML diagram code. Supports Context, Container, and Component levels.",
     inputSchema: {


### PR DESCRIPTION
## Summary

- Consolidate 50+ CLI commands into three core commands: `sync`, `status`, `query`
- Rename MCP tools to match CLI pattern (`query_*`, `status_*`)
- Add ADR-0041 (CLI Command Structure) and ADR-0042 (MCP Tool Naming)

## Breaking Changes

**CLI Commands:**
- `devac analyze` → `devac sync`
- `devac hub init/register/refresh` → `devac sync` (automatic)
- `devac validate` → `devac sync --validate`
- `devac watch` → `devac sync --watch`
- `devac find-symbol` → `devac query symbol`
- `devac deps` → `devac query deps`
- `devac diagnostics` → `devac status --diagnostics`
- `devac doctor` → `devac status --doctor`

**MCP Tools:**
- `find_symbol` → `query_symbol`
- `get_dependencies` → `query_deps`
- `get_validation_errors` → `status_diagnostics`
- etc.

## Test plan

- [x] All 417 CLI tests pass
- [x] All 95 MCP tests pass
- [ ] Manual testing of `devac sync`, `devac status`, `devac query` commands

🤖 Generated with [Claude Code](https://claude.ai/code)