### PR TITLE
fix: handle seedless repos and fix Stop hook output format

### DIFF
--- a/.changeset/fix-seedless-repos-stop-hook.md
+++ b/.changeset/fix-seedless-repos-stop-hook.md
@@ -1,0 +1,6 @@
+---
+"@pietgk/devac-core": patch
+"@pietgk/devac-cli": patch
+---
+
+Handle seedless repos gracefully during hub registration (skip instead of error) and fix Stop hook output to use `stopReason` instead of unsupported `hookSpecificOutput`

--- a/packages/devac-cli/__tests__/hub-register.test.ts
+++ b/packages/devac-cli/__tests__/hub-register.test.ts
@@ -90,7 +90,7 @@ describe("hub register command", () => {
     expect(result.error).toContain("does not exist");
   });
 
-  it("validates repo has .devac/seed/ directory", async () => {
+  it("skips repo with no .devac/seed/ directory", async () => {
     // Create repo without seed data
     await fs.mkdir(repoDir, { recursive: true });
 
@@ -100,8 +100,9 @@ describe("hub register command", () => {
       skipValidation: true,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("seed");
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Skipped");
+    expect(result.packages).toBe(0);
   });
 
   it("generates manifest if not present", async () => {

--- a/packages/devac-cli/__tests__/integration/hook-output.integration.test.ts
+++ b/packages/devac-cli/__tests__/integration/hook-output.integration.test.ts
@@ -298,7 +298,10 @@ Run get_all_diagnostics to see details.
       const result = harness.parseHookOutput(JSON.stringify(hookOutput));
 
       expect(result.valid).toBe(true);
-      expect(result.output?.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+      expect(result.output).not.toBeNull();
+      if (result.output && "hookSpecificOutput" in result.output) {
+        expect(result.output.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+      }
       expect(result.counts.errors).toBe(5);
       expect(result.counts.warnings).toBe(3);
     });

--- a/packages/devac-cli/__tests__/integration/hook-output.integration.test.ts
+++ b/packages/devac-cli/__tests__/integration/hook-output.integration.test.ts
@@ -8,10 +8,12 @@
 import * as path from "node:path";
 import {
   type HookOutput,
+  type StopHookOutput,
   ValidationTestHarness,
   extractReminderContent,
   parseDiagnosticsCounts,
   validateHookOutput,
+  validateStopHookOutput,
 } from "@pietgk/devac-core/test-harness";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
@@ -28,17 +30,14 @@ describe("Hook Output Integration", () => {
   });
 
   describe("Hook Output Schema Validation", () => {
-    test("valid hook output passes schema validation", () => {
+    test("valid Stop hook output passes schema validation", () => {
       const validOutput = {
-        hookSpecificOutput: {
-          hookEventName: "Stop",
-          additionalContext:
-            "<system-reminder>\nValidation found issues:\n- 2 TypeScript errors in src/error.ts\n</system-reminder>",
-        },
+        stopReason:
+          "Validation found issues:\n- 2 TypeScript errors in src/error.ts\n\nConsider fixing these before continuing.",
       };
 
-      const result = validateHookOutput(validOutput);
-      expect(result.hookSpecificOutput.hookEventName).toBe("Stop");
+      const result = validateStopHookOutput(validOutput);
+      expect(result.stopReason).toContain("Validation found issues");
     });
 
     test("UserPromptSubmit hook output is valid", () => {
@@ -65,10 +64,10 @@ describe("Hook Output Integration", () => {
       expect(() => validateHookOutput(invalidOutput)).toThrow();
     });
 
-    test("missing system-reminder tags throws", () => {
+    test("missing system-reminder tags in UserPromptSubmit throws", () => {
       const invalidOutput = {
         hookSpecificOutput: {
-          hookEventName: "Stop",
+          hookEventName: "UserPromptSubmit",
           additionalContext: "Missing system-reminder tags",
         },
       };
@@ -76,7 +75,7 @@ describe("Hook Output Integration", () => {
       expect(() => validateHookOutput(invalidOutput)).toThrow();
     });
 
-    test("missing hookSpecificOutput throws", () => {
+    test("missing hookSpecificOutput throws for UserPromptSubmit validation", () => {
       const invalidOutput = {
         someOtherField: "value",
       };
@@ -167,12 +166,9 @@ Line 3
   });
 
   describe("Harness Parse Methods", () => {
-    test("parseHookOutput handles valid JSON", () => {
+    test("parseHookOutput handles valid Stop hook JSON", () => {
       const stdout = JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "Stop",
-          additionalContext: "<system-reminder>\n5 errors, 3 warnings\n</system-reminder>",
-        },
+        stopReason: "Validation found issues:\n- 5 errors, 3 warnings\n\nConsider fixing these.",
       });
 
       const result = harness.parseHookOutput(stdout);
@@ -216,10 +212,10 @@ Line 3
   });
 
   describe("Harness Assertion Methods", () => {
-    test("assertHookOutputValid passes for valid output", () => {
+    test("assertHookOutputValid passes for valid UserPromptSubmit output", () => {
       const stdout = JSON.stringify({
         hookSpecificOutput: {
-          hookEventName: "Stop",
+          hookEventName: "UserPromptSubmit",
           additionalContext: "<system-reminder>Test</system-reminder>",
         },
       });
@@ -244,54 +240,46 @@ Line 3
 
   describe("Stop Hook Output Format", () => {
     test("Stop hook output includes TypeScript errors grouped by file", () => {
-      // Simulate what formatOnStopHookOutput would produce
-      const hookOutput: HookOutput = {
-        hookSpecificOutput: {
-          hookEventName: "Stop",
-          additionalContext: `<system-reminder>
-Validation found issues:
+      // Simulate what formatOnStopHookOutput produces
+      const hookOutput: StopHookOutput = {
+        stopReason: `Validation found issues:
 - 3 TypeScript errors in src/type-errors.ts
 - 2 TypeScript errors in src/index.ts
 
-Consider fixing these before continuing.
-</system-reminder>`,
-        },
+Consider fixing these before continuing.`,
       };
 
       const result = harness.parseHookOutput(JSON.stringify(hookOutput));
 
       expect(result.valid).toBe(true);
-      expect(result.output?.hookSpecificOutput.hookEventName).toBe("Stop");
+      expect(result.output).not.toBeNull();
 
-      if (!result.output) throw new Error("Expected output to be defined");
-      const content = extractReminderContent(result.output.hookSpecificOutput.additionalContext);
-      expect(content).toContain("Validation found issues:");
-      expect(content).toContain("TypeScript errors in src/type-errors.ts");
-      expect(content).toContain("Consider fixing these before continuing");
+      if (!result.output || !("stopReason" in result.output)) {
+        throw new Error("Expected StopHookOutput");
+      }
+      expect(result.output.stopReason).toContain("Validation found issues:");
+      expect(result.output.stopReason).toContain("TypeScript errors in src/type-errors.ts");
+      expect(result.output.stopReason).toContain("Consider fixing these before continuing");
     });
 
     test("Stop hook output includes ESLint errors and warnings", () => {
-      const hookOutput: HookOutput = {
-        hookSpecificOutput: {
-          hookEventName: "Stop",
-          additionalContext: `<system-reminder>
-Validation found issues:
+      const hookOutput: StopHookOutput = {
+        stopReason: `Validation found issues:
 - 2 errors, 3 warnings (ESLint) in src/lint-errors.ts
 
-Consider fixing these before continuing.
-</system-reminder>`,
-        },
+Consider fixing these before continuing.`,
       };
 
       const result = harness.parseHookOutput(JSON.stringify(hookOutput));
 
       expect(result.valid).toBe(true);
 
-      if (!result.output) throw new Error("Expected output to be defined");
-      const content = extractReminderContent(result.output.hookSpecificOutput.additionalContext);
-      expect(content).toContain("errors");
-      expect(content).toContain("warnings");
-      expect(content).toContain("ESLint");
+      if (!result.output || !("stopReason" in result.output)) {
+        throw new Error("Expected StopHookOutput");
+      }
+      expect(result.output.stopReason).toContain("errors");
+      expect(result.output.stopReason).toContain("warnings");
+      expect(result.output.stopReason).toContain("ESLint");
     });
   });
 

--- a/packages/devac-cli/src/commands/hub-register.ts
+++ b/packages/devac-cli/src/commands/hub-register.ts
@@ -65,6 +65,18 @@ async function registerSingleRepo(
   try {
     const result = await client.registerRepo(repoPath);
 
+    if (result.skipped) {
+      onProgress?.(`Skipped ${result.repoId} (${result.skipReason})`);
+
+      return {
+        success: true,
+        repoId: result.repoId,
+        packages: 0,
+        crossRepoEdges: 0,
+        message: `Skipped ${result.repoId} (${result.skipReason})`,
+      };
+    }
+
     onProgress?.(`Registered ${result.repoId} with ${result.packages} package(s)`);
 
     return {

--- a/packages/devac-cli/src/commands/sync.ts
+++ b/packages/devac-cli/src/commands/sync.ts
@@ -309,6 +309,10 @@ export async function syncCommand(options: SyncOptions): Promise<SyncResult> {
 
       try {
         const result = await client.registerRepo(repo.path);
+        if (result.skipped) {
+          onProgress?.(`  ⊘ ${repo.name}: skipped (${result.skipReason})`);
+          continue;
+        }
         reposRegistered++;
         onProgress?.(
           `  ✓ ${result.repoId}: ${result.packages} package(s), ${result.crossRepoEdges} cross-repo edges`

--- a/packages/devac-cli/src/commands/validate.ts
+++ b/packages/devac-cli/src/commands/validate.ts
@@ -333,10 +333,7 @@ function formatOnStopHookOutput(result: ValidateResult): string | null {
   }
 
   const hookOutput = {
-    hookSpecificOutput: {
-      hookEventName: "Stop",
-      additionalContext: `<system-reminder>\nValidation found issues:\n${issueLines.join("\n")}\n\nConsider fixing these before continuing.\n</system-reminder>`,
-    },
+    stopReason: `Validation found issues:\n${issueLines.join("\n")}\n\nConsider fixing these before continuing.`,
   };
 
   return JSON.stringify(hookOutput);

--- a/packages/devac-core/__tests__/central-hub.test.ts
+++ b/packages/devac-core/__tests__/central-hub.test.ts
@@ -193,11 +193,15 @@ describe("CentralHub", () => {
       expect(result.repoId).toBe("package/test-pkg");
     });
 
-    it("fails if repo has no .devac/seed/ directory", async () => {
+    it("returns skip result if repo has no .devac/seed/ directory", async () => {
       const repoPath = path.join(tempDir, "empty-repo");
       await fs.mkdir(repoPath, { recursive: true });
 
-      await expect(hub.registerRepo(repoPath)).rejects.toThrow();
+      const result = await hub.registerRepo(repoPath);
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe("no seeds");
+      expect(result.packages).toBe(0);
+      expect(result.crossRepoEdges).toBe(0);
     });
 
     it("unregisters repo and cleans up edges", async () => {

--- a/packages/devac-core/src/hub/central-hub.ts
+++ b/packages/devac-core/src/hub/central-hub.ts
@@ -54,6 +54,8 @@ export interface RepoRegistrationResult {
   repoId: string;
   packages: number;
   crossRepoEdges: number;
+  skipped?: boolean;
+  skipReason?: string;
 }
 
 /**
@@ -270,9 +272,13 @@ export class CentralHub {
     // Check if repo has seed data
     const hasSeed = await this.repoHasSeeds(repoPath);
     if (!hasSeed) {
-      throw new Error(
-        `Repository at ${repoPath} has no .devac/seed/ directory. Run 'devac sync' first.`
-      );
+      return {
+        repoId: path.basename(repoPath),
+        packages: 0,
+        crossRepoEdges: 0,
+        skipped: true,
+        skipReason: "no seeds",
+      };
     }
 
     // Generate or update manifest

--- a/packages/devac-core/src/test-harness/index.ts
+++ b/packages/devac-core/src/test-harness/index.ts
@@ -9,13 +9,17 @@
 export {
   HookOutputSchema,
   HookSpecificOutputSchema,
+  StopHookOutputSchema,
   DiagnosticsCountsSchema,
   validateHookOutput,
+  validateStopHookOutput,
   safeValidateHookOutput,
+  safeValidateStopHookOutput,
   extractReminderContent,
   parseDiagnosticsCounts,
   hasIssues,
   type HookOutput,
+  type StopHookOutput,
   type HookSpecificOutput,
   type DiagnosticsCounts,
 } from "./hook-output-schema.js";


### PR DESCRIPTION
## Summary

- **Seedless repos**: `registerRepo()` now returns a skip result instead of throwing when a repo has no `.devac/seed/` directory. This means `devac sync` reports infrastructure-only repos (e.g., `aws_infra_map_neo4j`) as "skipped" rather than errors.
- **Stop hook format**: Fixed the `devac validate --on-stop` JSON output to use top-level `stopReason` instead of `hookSpecificOutput` with `hookEventName: "Stop"`, which Claude Code does not support for Stop events.

## Test plan

- [x] `pnpm --filter @pietgk/devac-core test` — 2254 passed
- [x] `pnpm --filter @pietgk/devac-cli test` — 539 passed
- [x] `pnpm typecheck` — passes (verified by pre-push hook)
- [x] `pnpm test` — all packages pass (verified by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)